### PR TITLE
Removed <classifier> from the maven import, updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ For a Maven project, add the following to your `pom.xml` file:
   <groupId>io.testproject</groupId>
   <artifactId>java-sdk</artifactId>
   <version>0.65.3-RELEASE</version>
-  <classifier>sources</classifier>
 </dependency>
 ```
 


### PR DESCRIPTION
Updated README to remove <classifier>sources</classifier>
When using it, some users were not able to import, saying the SDK was not found.
Also, it does not match the maven import from here https://search.maven.org/artifact/io.testproject/java-sdk/0.65.3-RELEASE/jar
Signed-off-by: rantz <rantz@testproject.io>