### PR TITLE
Avoid NullPointerException when reporting Cucumber step.

### DIFF
--- a/src/main/java/io/testproject/sdk/internal/reporting/extensions/cucumber/CucumberReporter.java
+++ b/src/main/java/io/testproject/sdk/internal/reporting/extensions/cucumber/CucumberReporter.java
@@ -140,7 +140,8 @@ public class CucumberReporter implements EventListener {
         if (result.getStatus() == Status.PASSED) {
             stepPassed = true;
         } else {
-            String errorMessage = System.lineSeparator() + result.getError().getMessage();
+            String errorMessage = (result.getError() != null) ? System.lineSeparator()
+                    + result.getError().getMessage() : "";
             stepMessage = String.format("%s %s", stepMessage, errorMessage);
         }
 


### PR DESCRIPTION
When there is no step error, and the step failed, getting the message from NULL will cause a NullPointerException.
Checking if the message is NULL before attempting to get the message, if it is, use "" as the message.

Signed-off-by: david_goichman <david.goichman@testproject.io>