### PR TITLE
Avoid null pointer exception when creating Generic driver in Cucumber test.

### DIFF
--- a/src/main/java/io/testproject/sdk/drivers/GenericDriver.java
+++ b/src/main/java/io/testproject/sdk/drivers/GenericDriver.java
@@ -271,10 +271,10 @@ public final class GenericDriver implements ReportingDriver {
         AgentClient agentClient = AgentClient.getClient(remoteAddress, token, capabilities,
                         new ReportSettings(projectName, jobName), disableReports);
 
-        this.reporter = new Reporter(this, AgentClient.getClient(capabilities));
-
         reportingCommandExecutor = new GenericCommandExecutor(agentClient);
         reportingCommandExecutor.setReportsDisabled(disableReports);
+
+        this.reporter = new Reporter(this, AgentClient.getClient(capabilities));
     }
 
     /**


### PR DESCRIPTION
If running Cucumber, when creating the reporter, it will attempt to disable the auto test and command reports,
it will then cause a null pointer exception when the reporting command executor has not been created yet when
using a Generic driver.

Signed-off-by: david_goichman <david.goichman@testproject.io>