### PR TITLE
Allow to control report type - local / cloud or both

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,32 @@ ChromeDriver driver = new ChromeDriver(new ChromeOptions());
 driver.report().disableRedaction(true);
 ```
 
+## Cloud and Local Report
+
+By default, the execution report is uploaded to the cloud, and a local report is created, as an HTML file in a temporary folder.
+
+At the end of execution, the report is uploaded to the cloud and SDK outputs to the console/terminal the path for a local report file:
+
+`Execution Report: {temporary_folder}/report.html`
+
+This behavior can be controlled, by requesting only a `LOCAL` or only a `CLOUD` report.
+
+> When the Agent is offline, and only a _cloud_ report is requested, execution will fail with appropriate message.
+
+Via a driver constructor:
+
+```java
+ChromeDriver driver = new ChromeDriver(new ChromeOptions(), ReportType.LOCAL);
+```
+
+Or via the builder:
+
+```java
+ChromeDriver driver = new DriverBuilder<ChromeDriver>(new ChromeOptions())
+  .withReportType(ReportType.LOCAL)
+  .build(ChromeDriver.class);
+```
+
 # Logging
 
 TestProject SDK uses SLF4J API for logging.\

--- a/src/main/java/io/testproject/sdk/DriverBuilder.java
+++ b/src/main/java/io/testproject/sdk/DriverBuilder.java
@@ -21,6 +21,7 @@
 
 package io.testproject.sdk;
 
+import io.testproject.sdk.drivers.ReportType;
 import io.testproject.sdk.drivers.ReportingDriver;
 import org.apache.commons.lang3.reflect.ConstructorUtils;
 import org.openqa.selenium.Capabilities;
@@ -72,6 +73,11 @@ public final class DriverBuilder<T extends ReportingDriver> {
      * Enable / Disable reports flag.
      */
     private boolean builderDisableReports;
+
+    /**
+     * Report type to produce.
+     */
+    private ReportType builderReportType;
 
     /**
      * Initializes a new instance of the builder.
@@ -158,6 +164,16 @@ public final class DriverBuilder<T extends ReportingDriver> {
     }
 
     /**
+     * Set report type - cloud, local or both.
+     * @param reportType report type - cloud, local or both.
+     * @return Modified builder.
+     */
+    public DriverBuilder<T> withReportType(final ReportType reportType) {
+        this.builderReportType = reportType;
+        return this;
+    }
+
+    /**
      * Builds an instance of the requested driver using set values.
      *
      * @param clazz Required driver type.
@@ -189,7 +205,8 @@ public final class DriverBuilder<T extends ReportingDriver> {
                     builderCapabilities,
                     builderProjectName,
                     builderJobName,
-                    builderDisableReports);
+                    builderDisableReports,
+                    builderReportType);
         } catch (Exception e) {
             throw new WebDriverException("Failed to create an instance of " + clazz.getName(), e);
         }

--- a/src/main/java/io/testproject/sdk/drivers/GenericDriver.java
+++ b/src/main/java/io/testproject/sdk/drivers/GenericDriver.java
@@ -78,6 +78,28 @@ public final class GenericDriver implements ReportingDriver {
     }
 
     /**
+     * Initiates a new session with the Agent using default token and URL.
+     * <p>
+     * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     *
+     * @param reportType A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public GenericDriver(final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(false, reportType);
+    }
+
+    /**
      * Initiates a new session with the Agent using default token and URL and reports commands.
      * <p>
      * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
@@ -97,7 +119,31 @@ public final class GenericDriver implements ReportingDriver {
     public GenericDriver(final boolean disableReports)
             throws InvalidTokenException, AgentConnectException, IOException,
             ObsoleteVersionException {
-        this(null, null, null, null, disableReports);
+        this(null, null, null, null, disableReports, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using default token and URL and reports commands.
+     * <p>
+     * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param disableReports True to disable automatic reporting of driver commands and tests, otherwise False.
+     * @param reportType A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public GenericDriver(final boolean disableReports, final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(null, null, null, null, disableReports, reportType);
     }
 
     /**
@@ -120,7 +166,31 @@ public final class GenericDriver implements ReportingDriver {
     public GenericDriver(final String projectName)
             throws InvalidTokenException, AgentConnectException, IOException,
             ObsoleteVersionException {
-        this(null, null, projectName, null, false);
+        this(null, null, projectName, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using default token and URL with Project name.
+     * <p>
+     * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param projectName Project name to report
+     * @param reportType A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public GenericDriver(final String projectName, final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(null, null, projectName, null, false, reportType);
     }
 
     /**
@@ -145,7 +215,34 @@ public final class GenericDriver implements ReportingDriver {
                          final String jobName)
             throws InvalidTokenException, AgentConnectException, IOException,
             ObsoleteVersionException {
-        this(null, null, projectName, jobName, false);
+        this(null, null, projectName, jobName, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using default token and URL.
+     * <p>
+     * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param projectName Project name to report
+     * @param jobName     Job name to report
+     * @param reportType A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public GenericDriver(final String projectName,
+                         final String jobName,
+                         final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(null, null, projectName, jobName, false, reportType);
     }
 
     /**
@@ -168,7 +265,33 @@ public final class GenericDriver implements ReportingDriver {
     public GenericDriver(final String token, final String projectName, final String jobName)
             throws InvalidTokenException, AgentConnectException, IOException,
             ObsoleteVersionException {
-        this(null, token, projectName, jobName, false);
+        this(null, token, projectName, jobName, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided token and default URL and Project name.
+     * <p>
+     * Default Agent URL can be set using <em>TP_AGENT_URL</em> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param token       Development token that should be obtained from
+     *                    <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param projectName Project name to report
+     * @param jobName     Job name to report
+     * @param reportType A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public GenericDriver(final String token,
+                         final String projectName,
+                         final String jobName,
+                         final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, IOException, ObsoleteVersionException {
+        this(null, token, projectName, jobName, false, reportType);
     }
 
     /**
@@ -188,7 +311,28 @@ public final class GenericDriver implements ReportingDriver {
     public GenericDriver(final URL remoteAddress)
             throws InvalidTokenException, AgentConnectException, IOException,
             ObsoleteVersionException {
-        this(remoteAddress, null);
+        this(remoteAddress, null, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided Agent URL and default token.
+     * <p>
+     * Default token can be set using <em>TP_DEV_TOKEN</em> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param remoteAddress Agent API base URL (e.g. http://localhost:8585/)
+     * @param reportType A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public GenericDriver(final URL remoteAddress, final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(remoteAddress, null, reportType);
     }
 
     /**
@@ -212,7 +356,33 @@ public final class GenericDriver implements ReportingDriver {
                          final String jobName)
             throws InvalidTokenException, AgentConnectException, IOException,
             ObsoleteVersionException {
-        this(remoteAddress, null, projectName, jobName, false);
+        this(remoteAddress, null, projectName, jobName, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided Agent URL, default token, Project and Job names.
+     * <p>
+     * Default token can be set using <em>TP_DEV_TOKEN</em> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param remoteAddress Agent API base URL (e.g. http://localhost:8585/)
+     * @param projectName   Project name to report
+     * @param jobName       Job name to report
+     * @param reportType A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public GenericDriver(final URL remoteAddress,
+                         final String projectName,
+                         final String jobName,
+                         final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(remoteAddress, null, projectName, jobName, false, reportType);
     }
 
     /**
@@ -230,7 +400,27 @@ public final class GenericDriver implements ReportingDriver {
                          final String token)
             throws InvalidTokenException, AgentConnectException, IOException,
             ObsoleteVersionException {
-        this(remoteAddress, token, null, null, false);
+        this(remoteAddress, token, null, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided Agent URL and token.
+     *
+     * @param remoteAddress Agent API base URL (e.g. http://localhost:8585/)
+     * @param token         Development token that should be obtained from
+     *                      <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param reportType A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public GenericDriver(final URL remoteAddress,
+                         final String token,
+                         final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(remoteAddress, token, null, null, false, reportType);
     }
 
     /**
@@ -242,6 +432,7 @@ public final class GenericDriver implements ReportingDriver {
      * @param projectName    Project name to report
      * @param jobName        Job name to report
      * @param disableReports True to disable automatic reporting of driver commands and tests, otherwise False.
+     * @param reportType A type of report to produce - cloud, local or both.
      * @throws AgentConnectException    if Agent is not responding or responds with an error
      * @throws InvalidTokenException    if the token provided is invalid
      * @throws IOException              if the Agent API base URL provided is malformed
@@ -251,7 +442,8 @@ public final class GenericDriver implements ReportingDriver {
                          final String token,
                          final String projectName,
                          final String jobName,
-                         final boolean disableReports)
+                         final boolean disableReports,
+                         final ReportType reportType)
             throws InvalidTokenException, AgentConnectException, IOException,
             ObsoleteVersionException {
 
@@ -269,7 +461,7 @@ public final class GenericDriver implements ReportingDriver {
         }
 
         AgentClient agentClient = AgentClient.getClient(remoteAddress, token, capabilities,
-                        new ReportSettings(projectName, jobName), disableReports);
+                        new ReportSettings(projectName, jobName, reportType), disableReports);
 
         reportingCommandExecutor = new GenericCommandExecutor(agentClient);
         reportingCommandExecutor.setReportsDisabled(disableReports);

--- a/src/main/java/io/testproject/sdk/drivers/ReportType.java
+++ b/src/main/java/io/testproject/sdk/drivers/ReportType.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2020 TestProject LTD. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.testproject.sdk.drivers;
+
+/**
+ * Report type.
+ */
+public enum ReportType {
+
+    /**
+     * Cloud only report.
+     */
+    CLOUD,
+
+    /**
+     * Local only report.
+     */
+    LOCAL,
+
+    /**
+     * Both - cloud and local report.
+     */
+    CLOUD_AND_LOCAL
+}

--- a/src/main/java/io/testproject/sdk/drivers/android/AndroidDriver.java
+++ b/src/main/java/io/testproject/sdk/drivers/android/AndroidDriver.java
@@ -18,6 +18,7 @@
 package io.testproject.sdk.drivers.android;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.testproject.sdk.drivers.ReportType;
 import io.testproject.sdk.drivers.ReportingDriver;
 import io.testproject.sdk.internal.exceptions.AgentConnectException;
 import io.testproject.sdk.internal.exceptions.InvalidTokenException;
@@ -81,7 +82,31 @@ public class AndroidDriver<T extends WebElement>
     public AndroidDriver(final Capabilities capabilities)
             throws InvalidTokenException, AgentConnectException, MalformedURLException,
             ObsoleteVersionException {
-        this(null, null, capabilities, null, null, false);
+        this(null, null, capabilities, null, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using default token and URL.
+     * <p>
+     * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param capabilities take a look at {@link Capabilities}
+     * @param reportType A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public AndroidDriver(final Capabilities capabilities, final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, MalformedURLException,
+            ObsoleteVersionException {
+        this(null, null, capabilities, null, null, false, reportType);
     }
 
     /**
@@ -106,7 +131,34 @@ public class AndroidDriver<T extends WebElement>
                          final boolean disableReports)
             throws InvalidTokenException, AgentConnectException, MalformedURLException,
             ObsoleteVersionException {
-        this(null, null, capabilities, null, null, disableReports);
+        this(null, null, capabilities, null, null, disableReports, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using default token and URL.
+     * <p>
+     * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param capabilities   take a look at {@link Capabilities}
+     * @param disableReports True to disable automatic reporting of driver commands and tests, otherwise False.
+     * @param reportType     A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public AndroidDriver(final Capabilities capabilities,
+                         final boolean disableReports,
+                         final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, MalformedURLException,
+            ObsoleteVersionException {
+        this(null, null, capabilities, null, null, disableReports, reportType);
     }
 
     /**
@@ -131,7 +183,34 @@ public class AndroidDriver<T extends WebElement>
                          final String projectName)
             throws InvalidTokenException, AgentConnectException, MalformedURLException,
             ObsoleteVersionException {
-        this(null, null, capabilities, projectName, null, false);
+        this(null, null, capabilities, projectName, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using default token and URL with Project name.
+     * <p>
+     * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param capabilities take a look at {@link Capabilities}
+     * @param projectName  Project name to report
+     * @param reportType   A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public AndroidDriver(final Capabilities capabilities,
+                         final String projectName,
+                         final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, MalformedURLException,
+            ObsoleteVersionException {
+        this(null, null, capabilities, projectName, null, false, reportType);
     }
 
     /**
@@ -158,7 +237,36 @@ public class AndroidDriver<T extends WebElement>
                          final String jobName)
             throws InvalidTokenException, AgentConnectException, MalformedURLException,
             ObsoleteVersionException {
-        this(null, null, capabilities, projectName, jobName, false);
+        this(null, null, capabilities, projectName, jobName, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using default token and URL, Project and Job names.
+     * <p>
+     * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param capabilities take a look at {@link Capabilities}
+     * @param projectName  Project name to report
+     * @param jobName      Job name to report
+     * @param reportType   A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public AndroidDriver(final Capabilities capabilities,
+                         final String projectName,
+                         final String jobName,
+                         final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, MalformedURLException,
+            ObsoleteVersionException {
+        this(null, null, capabilities, projectName, jobName, false, reportType);
     }
 
     /**
@@ -181,7 +289,32 @@ public class AndroidDriver<T extends WebElement>
                          final Capabilities capabilities)
             throws AgentConnectException, InvalidTokenException, MalformedURLException,
             ObsoleteVersionException {
-        this(null, token, capabilities, null, null, false);
+        this(null, token, capabilities, null, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided token and default URL.
+     * <p>
+     * Default Agent URL can be set using <em>TP_AGENT_URL</em> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param token        Development token that should be obtained from
+     *                     <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param capabilities take a look at {@link Capabilities}
+     * @param reportType   A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public AndroidDriver(final String token,
+                         final Capabilities capabilities,
+                         final ReportType reportType)
+            throws AgentConnectException, InvalidTokenException, MalformedURLException,
+            ObsoleteVersionException {
+        this(null, token, capabilities, null, null, false, reportType);
     }
 
     /**
@@ -206,7 +339,34 @@ public class AndroidDriver<T extends WebElement>
                          final String projectName)
             throws AgentConnectException, InvalidTokenException, MalformedURLException,
             ObsoleteVersionException {
-        this(null, token, capabilities, projectName, null, false);
+        this(null, token, capabilities, projectName, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided token and default URL and Project name.
+     * <p>
+     * Default Agent URL can be set using <em>TP_AGENT_URL</em> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param token        Development token that should be obtained from
+     *                     <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param capabilities take a look at {@link Capabilities}
+     * @param projectName  Project name to report
+     * @param reportType   A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public AndroidDriver(final String token,
+                         final Capabilities capabilities,
+                         final String projectName,
+                         final ReportType reportType)
+            throws AgentConnectException, InvalidTokenException, MalformedURLException,
+            ObsoleteVersionException {
+        this(null, token, capabilities, projectName, null, false, reportType);
     }
 
     /**
@@ -233,7 +393,36 @@ public class AndroidDriver<T extends WebElement>
                          final String jobName)
             throws AgentConnectException, InvalidTokenException, MalformedURLException,
             ObsoleteVersionException {
-        this(null, token, capabilities, projectName, jobName, false);
+        this(null, token, capabilities, projectName, jobName, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided token and default URL, Project and Job names.
+     * <p>
+     * Default Agent URL can be set using <em>TP_AGENT_URL</em> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param token        Development token that should be obtained from
+     *                     <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param capabilities take a look at {@link Capabilities}
+     * @param projectName  Project name to report
+     * @param jobName      Job name to report
+     * @param reportType   A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public AndroidDriver(final String token,
+                         final Capabilities capabilities,
+                         final String projectName,
+                         final String jobName,
+                         final ReportType reportType)
+            throws AgentConnectException, InvalidTokenException, MalformedURLException,
+            ObsoleteVersionException {
+        this(null, token, capabilities, projectName, jobName, false, reportType);
     }
 
     /**
@@ -255,7 +444,31 @@ public class AndroidDriver<T extends WebElement>
                          final Capabilities capabilities)
             throws AgentConnectException, InvalidTokenException, MalformedURLException,
             ObsoleteVersionException {
-        this(remoteAddress, null, capabilities, null, null, false);
+        this(remoteAddress, null, capabilities, null, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided Agent URL and default token.
+     * <p>
+     * Default token can be set using <em>TP_DEV_TOKEN</em> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param remoteAddress Agent API base URL (e.g. http://localhost:8585/)
+     * @param capabilities  take a look at {@link Capabilities}
+     * @param reportType    A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public AndroidDriver(final URL remoteAddress,
+                         final Capabilities capabilities,
+                         final ReportType reportType)
+            throws AgentConnectException, InvalidTokenException, MalformedURLException,
+            ObsoleteVersionException {
+        this(remoteAddress, null, capabilities, null, null, false, reportType);
     }
 
     /**
@@ -279,7 +492,33 @@ public class AndroidDriver<T extends WebElement>
                          final String projectName)
             throws AgentConnectException, InvalidTokenException, MalformedURLException,
             ObsoleteVersionException {
-        this(remoteAddress, null, capabilities, projectName, null, false);
+        this(remoteAddress, null, capabilities, projectName, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided Agent URL, default token and Project name.
+     * <p>
+     * Default token can be set using <em>TP_DEV_TOKEN</em> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param remoteAddress Agent API base URL (e.g. http://localhost:8585/)
+     * @param capabilities  take a look at {@link Capabilities}
+     * @param projectName   Project name to report
+     * @param reportType    A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public AndroidDriver(final URL remoteAddress,
+                         final Capabilities capabilities,
+                         final String projectName,
+                         final ReportType reportType)
+            throws AgentConnectException, InvalidTokenException, MalformedURLException,
+            ObsoleteVersionException {
+        this(remoteAddress, null, capabilities, projectName, null, false, reportType);
     }
 
     /**
@@ -305,7 +544,35 @@ public class AndroidDriver<T extends WebElement>
                          final String jobName)
             throws AgentConnectException, InvalidTokenException, MalformedURLException,
             ObsoleteVersionException {
-        this(remoteAddress, null, capabilities, projectName, jobName, false);
+        this(remoteAddress, null, capabilities, projectName, jobName, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided Agent URL and default token, Project and Job names.
+     * <p>
+     * Default token can be set using <em>TP_DEV_TOKEN</em> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param remoteAddress Agent API base URL (e.g. http://localhost:8585/)
+     * @param capabilities  take a look at {@link Capabilities}
+     * @param projectName   Project name to report
+     * @param jobName       Job name to report
+     * @param reportType    A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public AndroidDriver(final URL remoteAddress,
+                         final Capabilities capabilities,
+                         final String projectName,
+                         final String jobName,
+                         final ReportType reportType)
+            throws AgentConnectException, InvalidTokenException, MalformedURLException,
+            ObsoleteVersionException {
+        this(remoteAddress, null, capabilities, projectName, jobName, false, reportType);
     }
 
     /**
@@ -325,7 +592,29 @@ public class AndroidDriver<T extends WebElement>
                          final Capabilities capabilities)
             throws AgentConnectException, InvalidTokenException, MalformedURLException,
             ObsoleteVersionException {
-        this(remoteAddress, token, capabilities, null, null, false);
+        this(remoteAddress, token, capabilities, null, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided Agent URL and token.
+     *
+     * @param remoteAddress Agent API base URL (e.g. http://localhost:8585/)
+     * @param token         Development token that should be obtained from
+     *                      <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param capabilities  take a look at {@link Capabilities}
+     * @param reportType    A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public AndroidDriver(final URL remoteAddress,
+                         final String token,
+                         final Capabilities capabilities,
+                         final ReportType reportType)
+            throws AgentConnectException, InvalidTokenException, MalformedURLException,
+            ObsoleteVersionException {
+        this(remoteAddress, token, capabilities, null, null, false, reportType);
     }
 
     /**
@@ -338,6 +627,7 @@ public class AndroidDriver<T extends WebElement>
      * @param projectName    Project name to report
      * @param jobName        Job name to report
      * @param disableReports True to disable automatic reporting of driver commands and tests, otherwise False.
+     * @param reportType     A type of report to produce - cloud, local or both.
      * @throws AgentConnectException    if Agent is not responding or responds with an error
      * @throws InvalidTokenException    if the token provided is invalid
      * @throws MalformedURLException    if the Agent API base URL provided is malformed
@@ -348,12 +638,13 @@ public class AndroidDriver<T extends WebElement>
                          final Capabilities capabilities,
                          final String projectName,
                          final String jobName,
-                         final boolean disableReports)
+                         final boolean disableReports,
+                         final ReportType reportType)
             throws AgentConnectException, InvalidTokenException, MalformedURLException,
             ObsoleteVersionException {
         super(DriverHelper.getHttpCommandExecutor(
                 AgentClient.getClient(remoteAddress, token, capabilities,
-                        new ReportSettings(projectName, jobName), disableReports), true),
+                        new ReportSettings(projectName, jobName, reportType), disableReports), true),
                 AgentClient.getClient(capabilities).getSession().getCapabilities());
 
         this.reporter = new Reporter(this, AgentClient.getClient(this.getCapabilities()));

--- a/src/main/java/io/testproject/sdk/drivers/ios/IOSDriver.java
+++ b/src/main/java/io/testproject/sdk/drivers/ios/IOSDriver.java
@@ -18,6 +18,7 @@
 package io.testproject.sdk.drivers.ios;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.testproject.sdk.drivers.ReportType;
 import io.testproject.sdk.drivers.ReportingDriver;
 import io.testproject.sdk.internal.exceptions.AgentConnectException;
 import io.testproject.sdk.internal.exceptions.InvalidTokenException;
@@ -81,7 +82,30 @@ public class IOSDriver<T extends WebElement>
      */
     public IOSDriver(final Capabilities capabilities) throws InvalidTokenException, AgentConnectException,
             MalformedURLException, ObsoleteVersionException {
-        this(null, null, capabilities, null, null, false);
+        this(null, null, capabilities, null, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using default token and URL.
+     * <p>
+     * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param capabilities take a look at {@link Capabilities}
+     * @param reportType   A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public IOSDriver(final Capabilities capabilities, final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, MalformedURLException, ObsoleteVersionException {
+        this(null, null, capabilities, null, null, false, reportType);
     }
 
     /**
@@ -105,7 +129,33 @@ public class IOSDriver<T extends WebElement>
     public IOSDriver(final Capabilities capabilities,
                      final boolean disableReports) throws InvalidTokenException, AgentConnectException,
             MalformedURLException, ObsoleteVersionException {
-        this(null, null, capabilities, null, null, disableReports);
+        this(null, null, capabilities, null, null, disableReports, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using default token and URL.
+     * <p>
+     * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param capabilities   take a look at {@link Capabilities}
+     * @param disableReports True to disable automatic reporting of driver commands and tests, otherwise False.
+     * @param reportType     A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public IOSDriver(final Capabilities capabilities,
+                     final boolean disableReports,
+                     final ReportType reportType) throws InvalidTokenException, AgentConnectException,
+            MalformedURLException, ObsoleteVersionException {
+        this(null, null, capabilities, null, null, disableReports, reportType);
     }
 
     /**
@@ -130,7 +180,34 @@ public class IOSDriver<T extends WebElement>
                      final String projectName)
             throws InvalidTokenException, AgentConnectException,
             MalformedURLException, ObsoleteVersionException {
-        this(null, null, capabilities, projectName, null, false);
+        this(null, null, capabilities, projectName, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using default token and URL with Project name.
+     * <p>
+     * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param capabilities take a look at {@link Capabilities}
+     * @param projectName  Project name to report
+     * @param reportType   A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public IOSDriver(final Capabilities capabilities,
+                     final String projectName,
+                     final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException,
+            MalformedURLException, ObsoleteVersionException {
+        this(null, null, capabilities, projectName, null, false, reportType);
     }
 
     /**
@@ -157,7 +234,36 @@ public class IOSDriver<T extends WebElement>
                      final String jobName)
             throws InvalidTokenException, AgentConnectException,
             MalformedURLException, ObsoleteVersionException {
-        this(null, null, capabilities, projectName, jobName, false);
+        this(null, null, capabilities, projectName, jobName, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using default token and URL, Project and Job names.
+     * <p>
+     * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param capabilities take a look at {@link Capabilities}
+     * @param projectName  Project name to report
+     * @param jobName      Job name to report
+     * @param reportType   A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public IOSDriver(final Capabilities capabilities,
+                     final String projectName,
+                     final String jobName,
+                     final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException,
+            MalformedURLException, ObsoleteVersionException {
+        this(null, null, capabilities, projectName, jobName, false, reportType);
     }
 
     /**
@@ -180,7 +286,32 @@ public class IOSDriver<T extends WebElement>
                      final Capabilities capabilities)
             throws AgentConnectException, InvalidTokenException, MalformedURLException,
             ObsoleteVersionException {
-        this(null, token, capabilities, null, null, false);
+        this(null, token, capabilities, null, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided token and default URL.
+     * <p>
+     * Default Agent URL can be set using <em>TP_AGENT_URL</em> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param token        Development token that should be obtained from
+     *                     <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param capabilities take a look at {@link Capabilities}
+     * @param reportType   A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public IOSDriver(final String token,
+                     final Capabilities capabilities,
+                     final ReportType reportType)
+            throws AgentConnectException, InvalidTokenException, MalformedURLException,
+            ObsoleteVersionException {
+        this(null, token, capabilities, null, null, false, reportType);
     }
 
     /**
@@ -205,7 +336,34 @@ public class IOSDriver<T extends WebElement>
                      final String projectName)
             throws AgentConnectException, InvalidTokenException, MalformedURLException,
             ObsoleteVersionException {
-        this(null, token, capabilities, projectName, null, false);
+        this(null, token, capabilities, projectName, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided token and default URL and Project name.
+     * <p>
+     * Default Agent URL can be set using <em>TP_AGENT_URL</em> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param token        Development token that should be obtained from
+     *                     <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param capabilities take a look at {@link Capabilities}
+     * @param projectName  Project name to report
+     * @param reportType    A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public IOSDriver(final String token,
+                     final Capabilities capabilities,
+                     final String projectName,
+                     final ReportType reportType)
+            throws AgentConnectException, InvalidTokenException, MalformedURLException,
+            ObsoleteVersionException {
+        this(null, token, capabilities, projectName, null, false, reportType);
     }
 
     /**
@@ -232,7 +390,36 @@ public class IOSDriver<T extends WebElement>
                      final String jobName)
             throws AgentConnectException, InvalidTokenException, MalformedURLException,
             ObsoleteVersionException {
-        this(null, token, capabilities, projectName, jobName, false);
+        this(null, token, capabilities, projectName, jobName, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided token and default URL, Project and Job names.
+     * <p>
+     * Default Agent URL can be set using <em>TP_AGENT_URL</em> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param token        Development token that should be obtained from
+     *                     <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param capabilities take a look at {@link Capabilities}
+     * @param projectName  Project name to report
+     * @param jobName      Job name to report
+     * @param reportType   A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public IOSDriver(final String token,
+                     final Capabilities capabilities,
+                     final String projectName,
+                     final String jobName,
+                     final ReportType reportType)
+            throws AgentConnectException, InvalidTokenException, MalformedURLException,
+            ObsoleteVersionException {
+        this(null, token, capabilities, projectName, jobName, false, reportType);
     }
 
     /**
@@ -254,7 +441,31 @@ public class IOSDriver<T extends WebElement>
                      final Capabilities capabilities)
             throws AgentConnectException, InvalidTokenException, MalformedURLException,
             ObsoleteVersionException {
-        this(remoteAddress, null, capabilities, null, null, false);
+        this(remoteAddress, null, capabilities, null, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided Agent URL and default token.
+     * <p>
+     * Default token can be set using <em>TP_DEV_TOKEN</em> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param remoteAddress Agent API base URL (e.g. http://localhost:8585/)
+     * @param capabilities  take a look at {@link Capabilities}
+     * @param reportType    A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public IOSDriver(final URL remoteAddress,
+                     final Capabilities capabilities,
+                     final ReportType reportType)
+            throws AgentConnectException, InvalidTokenException, MalformedURLException,
+            ObsoleteVersionException {
+        this(remoteAddress, null, capabilities, null, null, false, reportType);
     }
 
     /**
@@ -278,7 +489,33 @@ public class IOSDriver<T extends WebElement>
                      final String projectName)
             throws AgentConnectException, InvalidTokenException, MalformedURLException,
             ObsoleteVersionException {
-        this(remoteAddress, null, capabilities, projectName, null, false);
+        this(remoteAddress, null, capabilities, projectName, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided Agent URL, default token and Project name.
+     * <p>
+     * Default token can be set using <em>TP_DEV_TOKEN</em> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param remoteAddress Agent API base URL (e.g. http://localhost:8585/)
+     * @param capabilities  take a look at {@link Capabilities}
+     * @param projectName   Project name to report
+     * @param reportType    A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public IOSDriver(final URL remoteAddress,
+                     final Capabilities capabilities,
+                     final String projectName,
+                     final ReportType reportType)
+            throws AgentConnectException, InvalidTokenException, MalformedURLException,
+            ObsoleteVersionException {
+        this(remoteAddress, null, capabilities, projectName, null, false, reportType);
     }
 
     /**
@@ -304,7 +541,35 @@ public class IOSDriver<T extends WebElement>
                      final String jobName)
             throws AgentConnectException, InvalidTokenException, MalformedURLException,
             ObsoleteVersionException {
-        this(remoteAddress, null, capabilities, projectName, jobName, false);
+        this(remoteAddress, null, capabilities, projectName, jobName, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided Agent URL and default token, Project and Job names.
+     * <p>
+     * Default token can be set using <em>TP_DEV_TOKEN</em> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param remoteAddress Agent API base URL (e.g. http://localhost:8585/)
+     * @param capabilities  take a look at {@link Capabilities}
+     * @param projectName   Project name to report
+     * @param jobName       Job name to report
+     * @param reportType    A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public IOSDriver(final URL remoteAddress,
+                     final Capabilities capabilities,
+                     final String projectName,
+                     final String jobName,
+                     final ReportType reportType)
+            throws AgentConnectException, InvalidTokenException, MalformedURLException,
+            ObsoleteVersionException {
+        this(remoteAddress, null, capabilities, projectName, jobName, false, reportType);
     }
 
     /**
@@ -324,7 +589,29 @@ public class IOSDriver<T extends WebElement>
                      final Capabilities capabilities)
             throws AgentConnectException, InvalidTokenException, MalformedURLException,
             ObsoleteVersionException {
-        this(remoteAddress, token, capabilities, null, null, false);
+        this(remoteAddress, token, capabilities, null, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided Agent URL and token.
+     *
+     * @param remoteAddress Agent API base URL (e.g. http://localhost:8585/)
+     * @param token         Development token that should be obtained from
+     *                      <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param capabilities  take a look at {@link Capabilities}
+     * @param reportType    A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public IOSDriver(final URL remoteAddress,
+                     final String token,
+                     final Capabilities capabilities,
+                     final ReportType reportType)
+            throws AgentConnectException, InvalidTokenException, MalformedURLException,
+            ObsoleteVersionException {
+        this(remoteAddress, token, capabilities, null, null, false, reportType);
     }
 
     /**
@@ -337,6 +624,7 @@ public class IOSDriver<T extends WebElement>
      * @param projectName    Project name to report
      * @param jobName        Job name to report
      * @param disableReports True to disable automatic reporting of driver commands and tests, otherwise False.
+     * @param reportType     A type of report to produce - cloud, local or both.
      * @throws AgentConnectException    if Agent is not responding or responds with an error
      * @throws InvalidTokenException    if the token provided is invalid
      * @throws MalformedURLException    if the Agent API base URL provided is malformed
@@ -347,12 +635,13 @@ public class IOSDriver<T extends WebElement>
                      final Capabilities capabilities,
                      final String projectName,
                      final String jobName,
-                     final boolean disableReports)
+                     final boolean disableReports,
+                     final ReportType reportType)
             throws AgentConnectException, InvalidTokenException, MalformedURLException,
             ObsoleteVersionException {
         super(DriverHelper.getHttpCommandExecutor(
                 AgentClient.getClient(remoteAddress, token, capabilities,
-                        new ReportSettings(projectName, jobName), disableReports), true),
+                        new ReportSettings(projectName, jobName, reportType), disableReports), true),
                 AgentClient.getClient(capabilities).getSession().getCapabilities());
 
         this.reporter = new Reporter(this, AgentClient.getClient(this.getCapabilities()));

--- a/src/main/java/io/testproject/sdk/drivers/web/ChromeDriver.java
+++ b/src/main/java/io/testproject/sdk/drivers/web/ChromeDriver.java
@@ -18,6 +18,7 @@
 package io.testproject.sdk.drivers.web;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.testproject.sdk.drivers.ReportType;
 import io.testproject.sdk.drivers.ReportingDriver;
 import io.testproject.sdk.internal.exceptions.AgentConnectException;
 import io.testproject.sdk.internal.exceptions.InvalidTokenException;
@@ -61,12 +62,35 @@ public class ChromeDriver extends org.openqa.selenium.chrome.ChromeDriver implem
      * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
      * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
      * <p>
+     *
      * @throws AgentConnectException    if Agent is not responding or responds with an error
      * @throws InvalidTokenException    if the token provided is invalid
      * @throws IOException              if the Agent API base URL provided is malformed
      * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
      */
     public ChromeDriver()
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(null, null, new ChromeOptions());
+    }
+
+    /**
+     * Initiates a new session with the Agent using default token and URL.
+     * <p>
+     * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     *
+     * @param reportType A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public ChromeDriver(final ReportType reportType)
             throws InvalidTokenException, AgentConnectException, IOException,
             ObsoleteVersionException {
         this(null, null, new ChromeOptions());
@@ -96,6 +120,30 @@ public class ChromeDriver extends org.openqa.selenium.chrome.ChromeDriver implem
     }
 
     /**
+     * Initiates a new session with the Agent using default token and URL.
+     * <p>
+     * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param options    take a look at {@link ChromeOptions}
+     * @param reportType A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public ChromeDriver(final ChromeOptions options, final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(null, null, options, reportType);
+    }
+
+    /**
      * Initiates a new session with the Agent using default token and URL and reports commands.
      * <p>
      * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
@@ -117,7 +165,34 @@ public class ChromeDriver extends org.openqa.selenium.chrome.ChromeDriver implem
                         final boolean disableReports)
             throws InvalidTokenException, AgentConnectException, IOException,
             ObsoleteVersionException {
-        this(null, null, options, null, null, disableReports);
+        this(null, null, options, null, null, disableReports, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using default token and URL and reports commands.
+     * <p>
+     * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param options        take a look at {@link ChromeOptions}
+     * @param disableReports True to disable automatic reporting of driver commands and tests, otherwise False.
+     * @param reportType     A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public ChromeDriver(final ChromeOptions options,
+                        final boolean disableReports,
+                        final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(null, null, options, null, null, disableReports, reportType);
     }
 
     /**
@@ -142,7 +217,34 @@ public class ChromeDriver extends org.openqa.selenium.chrome.ChromeDriver implem
                         final String projectName)
             throws InvalidTokenException, AgentConnectException, IOException,
             ObsoleteVersionException {
-        this(null, null, options, projectName, null, false);
+        this(null, null, options, projectName, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using default token and URL with Project name.
+     * <p>
+     * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param options     take a look at {@link ChromeOptions}
+     * @param projectName Project name to report
+     * @param reportType  A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public ChromeDriver(final ChromeOptions options,
+                        final String projectName,
+                        final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(null, null, options, projectName, null, false, reportType);
     }
 
     /**
@@ -169,7 +271,36 @@ public class ChromeDriver extends org.openqa.selenium.chrome.ChromeDriver implem
                         final String jobName)
             throws InvalidTokenException, AgentConnectException, IOException,
             ObsoleteVersionException {
-        this(null, null, options, projectName, jobName, false);
+        this(null, null, options, projectName, jobName, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using default token and URL.
+     * <p>
+     * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param options     take a look at {@link ChromeOptions}
+     * @param projectName Project name to report
+     * @param jobName     Job name to report
+     * @param reportType  A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public ChromeDriver(final ChromeOptions options,
+                        final String projectName,
+                        final String jobName,
+                        final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(null, null, options, projectName, jobName, false, reportType);
     }
 
     /**
@@ -196,6 +327,31 @@ public class ChromeDriver extends org.openqa.selenium.chrome.ChromeDriver implem
     }
 
     /**
+     * Initiates a new session with the Agent using provided token and default URL.
+     * <p>
+     * Default Agent URL can be set using <em>TP_AGENT_URL</em> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param token      Development token that should be obtained from
+     *                   <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param options    take a look at {@link ChromeOptions}
+     * @param reportType A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public ChromeDriver(final String token,
+                        final ChromeOptions options,
+                        final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(null, token, options, reportType);
+    }
+
+    /**
      * Initiates a new session with the Agent using provided token and default URL and Project name.
      * <p>
      * Default Agent URL can be set using <em>TP_AGENT_URL</em> environment variable.
@@ -215,7 +371,34 @@ public class ChromeDriver extends org.openqa.selenium.chrome.ChromeDriver implem
     public ChromeDriver(final String token, final ChromeOptions options, final String projectName)
             throws InvalidTokenException, AgentConnectException, IOException,
             ObsoleteVersionException {
-        this(null, token, options, projectName, null, false);
+        this(null, token, options, projectName, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided token and default URL and Project name.
+     * <p>
+     * Default Agent URL can be set using <em>TP_AGENT_URL</em> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param token       Development token that should be obtained from
+     *                    <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param options     take a look at {@link ChromeOptions}
+     * @param projectName Project name to report
+     * @param reportType  A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public ChromeDriver(final String token,
+                        final ChromeOptions options,
+                        final String projectName,
+                        final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(null, token, options, projectName, null, false, reportType);
     }
 
     /**
@@ -240,7 +423,33 @@ public class ChromeDriver extends org.openqa.selenium.chrome.ChromeDriver implem
                         final String projectName, final String jobName)
             throws InvalidTokenException, AgentConnectException, IOException,
             ObsoleteVersionException {
-        this(null, token, options, projectName, jobName, false);
+        this(null, token, options, projectName, jobName, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided token and default URL, Project and Job names.
+     * <p>
+     * Default Agent URL can be set using <em>TP_AGENT_URL</em> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param token       Development token that should be obtained from
+     *                    <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param options     take a look at {@link ChromeOptions}
+     * @param projectName Project name to report
+     * @param jobName     Job name to report
+     * @param reportType  A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public ChromeDriver(final String token, final ChromeOptions options,
+                        final String projectName, final String jobName, final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(null, token, options, projectName, jobName, false, reportType);
     }
 
     /**
@@ -266,6 +475,30 @@ public class ChromeDriver extends org.openqa.selenium.chrome.ChromeDriver implem
     }
 
     /**
+     * Initiates a new session with the Agent using provided Agent URL and default token.
+     * <p>
+     * Default token can be set using <em>TP_DEV_TOKEN</em> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param remoteAddress Agent API base URL (e.g. http://localhost:8585/)
+     * @param options       take a look at {@link ChromeOptions}
+     * @param reportType    A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public ChromeDriver(final URL remoteAddress,
+                        final ChromeOptions options,
+                        final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(remoteAddress, null, options, reportType);
+    }
+
+    /**
      * Initiates a new session with the Agent using provided Agent URL, default token and Project name.
      * <p>
      * Default token can be set using <em>TP_DEV_TOKEN</em> environment variable.
@@ -286,7 +519,33 @@ public class ChromeDriver extends org.openqa.selenium.chrome.ChromeDriver implem
                         final String projectName)
             throws InvalidTokenException, AgentConnectException, IOException,
             ObsoleteVersionException {
-        this(remoteAddress, null, options, projectName, null, false);
+        this(remoteAddress, null, options, projectName, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided Agent URL, default token and Project name.
+     * <p>
+     * Default token can be set using <em>TP_DEV_TOKEN</em> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param remoteAddress Agent API base URL (e.g. http://localhost:8585/)
+     * @param options       take a look at {@link ChromeOptions}
+     * @param projectName   Project name to report
+     * @param reportType    A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public ChromeDriver(final URL remoteAddress,
+                        final ChromeOptions options,
+                        final String projectName,
+                        final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(remoteAddress, null, options, projectName, null, false, reportType);
     }
 
     /**
@@ -312,7 +571,35 @@ public class ChromeDriver extends org.openqa.selenium.chrome.ChromeDriver implem
                         final String jobName)
             throws InvalidTokenException, AgentConnectException, IOException,
             ObsoleteVersionException {
-        this(remoteAddress, null, options, projectName, jobName, false);
+        this(remoteAddress, null, options, projectName, jobName, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided Agent URL, default token, Project and Job names.
+     * <p>
+     * Default token can be set using <em>TP_DEV_TOKEN</em> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param remoteAddress Agent API base URL (e.g. http://localhost:8585/)
+     * @param options       take a look at {@link ChromeOptions}
+     * @param projectName   Project name to report
+     * @param jobName       Job name to report
+     * @param reportType    A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public ChromeDriver(final URL remoteAddress,
+                        final ChromeOptions options,
+                        final String projectName,
+                        final String jobName,
+                        final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(remoteAddress, null, options, projectName, jobName, false, reportType);
     }
 
     /**
@@ -332,7 +619,29 @@ public class ChromeDriver extends org.openqa.selenium.chrome.ChromeDriver implem
                         final ChromeOptions options)
             throws InvalidTokenException, AgentConnectException, IOException,
             ObsoleteVersionException {
-        this(remoteAddress, token, options, null, null, false);
+        this(remoteAddress, token, options, null, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided Agent URL and token.
+     *
+     * @param remoteAddress Agent API base URL (e.g. http://localhost:8585/)
+     * @param token         Development token that should be obtained from
+     *                      <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param options       take a look at {@link ChromeOptions}
+     * @param reportType    A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public ChromeDriver(final URL remoteAddress,
+                        final String token,
+                        final ChromeOptions options,
+                        final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(remoteAddress, token, options, null, null, false, reportType);
     }
 
     /**
@@ -345,6 +654,7 @@ public class ChromeDriver extends org.openqa.selenium.chrome.ChromeDriver implem
      * @param projectName    Project name to report
      * @param jobName        Job name to report
      * @param disableReports True to disable automatic reporting of driver commands and tests, otherwise False.
+     * @param reportType     A type of report to produce - cloud, local or both.
      * @throws AgentConnectException    if Agent is not responding or responds with an error
      * @throws InvalidTokenException    if the token provided is invalid
      * @throws IOException              if the Agent API base URL provided is malformed
@@ -355,12 +665,13 @@ public class ChromeDriver extends org.openqa.selenium.chrome.ChromeDriver implem
                         final ChromeOptions options,
                         final String projectName,
                         final String jobName,
-                        final boolean disableReports)
+                        final boolean disableReports,
+                        final ReportType reportType)
             throws InvalidTokenException, AgentConnectException, IOException,
             ObsoleteVersionException {
         super(new FakeDriverService(), new ChromeOptions().merge(AgentClient
                 .getClient(remoteAddress, token, options,
-                        new ReportSettings(projectName, jobName), disableReports)
+                        new ReportSettings(projectName, jobName, reportType), disableReports)
                 .getSession().getCapabilities()));
 
         this.reporter = new Reporter(this, AgentClient.getClient(this.getCapabilities()));

--- a/src/main/java/io/testproject/sdk/drivers/web/EdgeDriver.java
+++ b/src/main/java/io/testproject/sdk/drivers/web/EdgeDriver.java
@@ -18,6 +18,7 @@
 package io.testproject.sdk.drivers.web;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.testproject.sdk.drivers.ReportType;
 import io.testproject.sdk.drivers.ReportingDriver;
 import io.testproject.sdk.internal.exceptions.AgentConnectException;
 import io.testproject.sdk.internal.exceptions.InvalidTokenException;
@@ -61,6 +62,7 @@ public class EdgeDriver extends org.openqa.selenium.edge.EdgeDriver implements R
      * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
      * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
      * <p>
+     *
      * @throws AgentConnectException    if Agent is not responding or responds with an error
      * @throws InvalidTokenException    if the token provided is invalid
      * @throws IOException              if the Agent API base URL provided is malformed
@@ -70,6 +72,28 @@ public class EdgeDriver extends org.openqa.selenium.edge.EdgeDriver implements R
             throws InvalidTokenException, AgentConnectException, IOException,
             ObsoleteVersionException {
         this(null, null, new EdgeOptions());
+    }
+
+    /**
+     * Initiates a new session with the Agent using default token and URL.
+     * <p>
+     * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     *
+     * @param reportType A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public EdgeDriver(final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(null, null, new EdgeOptions(), reportType);
     }
 
     /**
@@ -106,6 +130,30 @@ public class EdgeDriver extends org.openqa.selenium.edge.EdgeDriver implements R
      * <p>
      * Creates a new instance based on {@code capabilities}.
      *
+     * @param options    take a look at {@link EdgeOptions}
+     * @param reportType A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public EdgeDriver(final EdgeOptions options, final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(null, null, options, reportType);
+    }
+
+    /**
+     * Initiates a new session with the Agent using default token and URL.
+     * <p>
+     * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
      * @param options        take a look at {@link EdgeOptions}
      * @param disableReports True to disable automatic reporting of driver commands and tests, otherwise False.
      * @throws AgentConnectException    if Agent is not responding or responds with an error
@@ -117,7 +165,34 @@ public class EdgeDriver extends org.openqa.selenium.edge.EdgeDriver implements R
                       final boolean disableReports)
             throws InvalidTokenException, AgentConnectException, IOException,
             ObsoleteVersionException {
-        this(null, null, options, null, null, disableReports);
+        this(null, null, options, null, null, disableReports, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using default token and URL.
+     * <p>
+     * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param options        take a look at {@link EdgeOptions}
+     * @param disableReports True to disable automatic reporting of driver commands and tests, otherwise False.
+     * @param reportType     A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public EdgeDriver(final EdgeOptions options,
+                      final boolean disableReports,
+                      final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(null, null, options, null, null, disableReports, reportType);
     }
 
     /**
@@ -142,7 +217,34 @@ public class EdgeDriver extends org.openqa.selenium.edge.EdgeDriver implements R
                       final String projectName)
             throws InvalidTokenException, AgentConnectException, IOException,
             ObsoleteVersionException {
-        this(null, null, options, projectName, null, false);
+        this(null, null, options, projectName, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using default token and URL with Project name.
+     * <p>
+     * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param options     take a look at {@link EdgeOptions}
+     * @param projectName Project name to report
+     * @param reportType  A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public EdgeDriver(final EdgeOptions options,
+                      final String projectName,
+                      final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(null, null, options, projectName, null, false, reportType);
     }
 
     /**
@@ -169,7 +271,36 @@ public class EdgeDriver extends org.openqa.selenium.edge.EdgeDriver implements R
                       final String jobName)
             throws InvalidTokenException, AgentConnectException, IOException,
             ObsoleteVersionException {
-        this(null, null, options, projectName, jobName, false);
+        this(null, null, options, projectName, jobName, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using default token and URL, Project and Job names.
+     * <p>
+     * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param options     take a look at {@link EdgeOptions}
+     * @param projectName Project name to report
+     * @param jobName     Job name to report
+     * @param reportType  A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public EdgeDriver(final EdgeOptions options,
+                      final String projectName,
+                      final String jobName,
+                      final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(null, null, options, projectName, jobName, false, reportType);
     }
 
     /**
@@ -192,7 +323,32 @@ public class EdgeDriver extends org.openqa.selenium.edge.EdgeDriver implements R
                       final EdgeOptions options)
             throws InvalidTokenException, AgentConnectException, IOException,
             ObsoleteVersionException {
-        this(null, token, options, null, null, false);
+        this(null, token, options, null, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided token and default URL.
+     * <p>
+     * Default Agent URL can be set using <em>TP_AGENT_URL</em> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param token      Development token that should be obtained from
+     *                   <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param options    take a look at {@link EdgeOptions}
+     * @param reportType A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public EdgeDriver(final String token,
+                      final EdgeOptions options,
+                      final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(null, token, options, null, null, false, reportType);
     }
 
     /**
@@ -217,7 +373,34 @@ public class EdgeDriver extends org.openqa.selenium.edge.EdgeDriver implements R
                       final String projectName)
             throws InvalidTokenException, AgentConnectException, IOException,
             ObsoleteVersionException {
-        this(null, token, options, projectName, null, false);
+        this(null, token, options, projectName, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided token and default URL with Project name.
+     * <p>
+     * Default Agent URL can be set using <em>TP_AGENT_URL</em> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param token       Development token that should be obtained from
+     *                    <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param options     take a look at {@link EdgeOptions}
+     * @param projectName Project name to report
+     * @param reportType  A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public EdgeDriver(final String token,
+                      final EdgeOptions options,
+                      final String projectName,
+                      final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(null, token, options, projectName, null, false, reportType);
     }
 
     /**
@@ -244,7 +427,36 @@ public class EdgeDriver extends org.openqa.selenium.edge.EdgeDriver implements R
                       final String jobName)
             throws InvalidTokenException, AgentConnectException, IOException,
             ObsoleteVersionException {
-        this(null, token, options, projectName, jobName, false);
+        this(null, token, options, projectName, jobName, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided token and default URL, Project and Job names.
+     * <p>
+     * Default Agent URL can be set using <em>TP_AGENT_URL</em> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param token       Development token that should be obtained from
+     *                    <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param options     take a look at {@link EdgeOptions}
+     * @param projectName Project name to report
+     * @param jobName     Job name to report
+     * @param reportType  A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public EdgeDriver(final String token,
+                      final EdgeOptions options,
+                      final String projectName,
+                      final String jobName,
+                      final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(null, token, options, projectName, jobName, false, reportType);
     }
 
     /**
@@ -266,7 +478,31 @@ public class EdgeDriver extends org.openqa.selenium.edge.EdgeDriver implements R
                       final EdgeOptions options)
             throws InvalidTokenException, AgentConnectException, IOException,
             ObsoleteVersionException {
-        this(remoteAddress, null, options, null, null, false);
+        this(remoteAddress, null, options, null, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided Agent URL and default token.
+     * <p>
+     * Default token can be set using <em>TP_DEV_TOKEN</em> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param remoteAddress Agent API base URL (e.g. http://localhost:8585/)
+     * @param options       take a look at {@link EdgeOptions}
+     * @param reportType    A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public EdgeDriver(final URL remoteAddress,
+                      final EdgeOptions options,
+                      final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(remoteAddress, null, options, null, null, false, reportType);
     }
 
     /**
@@ -290,7 +526,33 @@ public class EdgeDriver extends org.openqa.selenium.edge.EdgeDriver implements R
                       final String projectName)
             throws InvalidTokenException, AgentConnectException, IOException,
             ObsoleteVersionException {
-        this(remoteAddress, null, options, projectName, null, false);
+        this(remoteAddress, null, options, projectName, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided Agent URL and default token with Project name.
+     * <p>
+     * Default token can be set using <em>TP_DEV_TOKEN</em> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param remoteAddress Agent API base URL (e.g. http://localhost:8585/)
+     * @param options       take a look at {@link EdgeOptions}
+     * @param projectName   Project name to report
+     * @param reportType    A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public EdgeDriver(final URL remoteAddress,
+                      final EdgeOptions options,
+                      final String projectName,
+                      final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(remoteAddress, null, options, projectName, null, false, reportType);
     }
 
     /**
@@ -316,7 +578,35 @@ public class EdgeDriver extends org.openqa.selenium.edge.EdgeDriver implements R
                       final String jobName)
             throws InvalidTokenException, AgentConnectException, IOException,
             ObsoleteVersionException {
-        this(remoteAddress, null, options, projectName, jobName, false);
+        this(remoteAddress, null, options, projectName, jobName, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided Agent URL and default token, Project and Job names.
+     * <p>
+     * Default token can be set using <em>TP_DEV_TOKEN</em> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param remoteAddress Agent API base URL (e.g. http://localhost:8585/)
+     * @param options       take a look at {@link EdgeOptions}
+     * @param projectName   Project name to report
+     * @param jobName       Job name to report
+     * @param reportType    A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public EdgeDriver(final URL remoteAddress,
+                      final EdgeOptions options,
+                      final String projectName,
+                      final String jobName,
+                      final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(remoteAddress, null, options, projectName, jobName, false, reportType);
     }
 
     /**
@@ -336,7 +626,29 @@ public class EdgeDriver extends org.openqa.selenium.edge.EdgeDriver implements R
                       final EdgeOptions options)
             throws InvalidTokenException, AgentConnectException, IOException,
             ObsoleteVersionException {
-        this(remoteAddress, token, options, null, null, false);
+        this(remoteAddress, token, options, null, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided Agent URL and token.
+     *
+     * @param remoteAddress Agent API base URL (e.g. http://localhost:8585/)
+     * @param token         Development token that should be obtained from
+     *                      <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param options       take a look at {@link EdgeOptions}
+     * @param reportType    A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public EdgeDriver(final URL remoteAddress,
+                      final String token,
+                      final EdgeOptions options,
+                      final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(remoteAddress, token, options, null, null, false, reportType);
     }
 
     /**
@@ -349,6 +661,7 @@ public class EdgeDriver extends org.openqa.selenium.edge.EdgeDriver implements R
      * @param projectName    Project name to report
      * @param jobName        Job name to report
      * @param disableReports True to disable automatic reporting of driver commands and tests, otherwise False.
+     * @param reportType     A type of report to produce - cloud, local or both.
      * @throws AgentConnectException    if Agent is not responding or responds with an error
      * @throws InvalidTokenException    if the token provided is invalid
      * @throws IOException              if the Agent API base URL provided is malformed
@@ -359,12 +672,13 @@ public class EdgeDriver extends org.openqa.selenium.edge.EdgeDriver implements R
                       final EdgeOptions options,
                       final String projectName,
                       final String jobName,
-                      final boolean disableReports)
+                      final boolean disableReports,
+                      final ReportType reportType)
             throws InvalidTokenException, AgentConnectException, IOException,
             ObsoleteVersionException {
         super(new FakeDriverService(), new EdgeOptions().merge(AgentClient
                 .getClient(remoteAddress, token, options,
-                        new ReportSettings(projectName, jobName), disableReports)
+                        new ReportSettings(projectName, jobName, reportType), disableReports)
                 .getSession().getCapabilities()));
 
         this.reporter = new Reporter(this, AgentClient.getClient(this.getCapabilities()));

--- a/src/main/java/io/testproject/sdk/drivers/web/FirefoxDriver.java
+++ b/src/main/java/io/testproject/sdk/drivers/web/FirefoxDriver.java
@@ -18,6 +18,7 @@
 package io.testproject.sdk.drivers.web;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.testproject.sdk.drivers.ReportType;
 import io.testproject.sdk.drivers.ReportingDriver;
 import io.testproject.sdk.internal.exceptions.AgentConnectException;
 import io.testproject.sdk.internal.exceptions.InvalidTokenException;
@@ -61,6 +62,7 @@ public class FirefoxDriver extends org.openqa.selenium.firefox.FirefoxDriver imp
      * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
      * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
      * <p>
+     *
      * @throws AgentConnectException    if Agent is not responding or responds with an error
      * @throws InvalidTokenException    if the token provided is invalid
      * @throws IOException              if the Agent API base URL provided is malformed
@@ -70,6 +72,28 @@ public class FirefoxDriver extends org.openqa.selenium.firefox.FirefoxDriver imp
             throws InvalidTokenException, AgentConnectException, IOException,
             ObsoleteVersionException {
         this(null, null, new FirefoxOptions());
+    }
+
+    /**
+     * Initiates a new session with the Agent using default token and URL.
+     * <p>
+     * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     *
+     * @param reportType A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public FirefoxDriver(final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(null, null, new FirefoxOptions(), reportType);
     }
 
     /**
@@ -106,6 +130,30 @@ public class FirefoxDriver extends org.openqa.selenium.firefox.FirefoxDriver imp
      * <p>
      * Creates a new instance based on {@code capabilities}.
      *
+     * @param options    take a look at {@link FirefoxOptions}
+     * @param reportType A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public FirefoxDriver(final FirefoxOptions options, final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(null, null, options, reportType);
+    }
+
+    /**
+     * Initiates a new session with the Agent using default token and URL.
+     * <p>
+     * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
      * @param options        take a look at {@link FirefoxOptions}
      * @param disableReports True to disable automatic reporting of driver commands and tests, otherwise False.
      * @throws AgentConnectException    if Agent is not responding or responds with an error
@@ -117,7 +165,34 @@ public class FirefoxDriver extends org.openqa.selenium.firefox.FirefoxDriver imp
                          final boolean disableReports)
             throws InvalidTokenException, AgentConnectException, IOException,
             ObsoleteVersionException {
-        this(null, null, options, null, null, disableReports);
+        this(null, null, options, null, null, disableReports, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using default token and URL.
+     * <p>
+     * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param options        take a look at {@link FirefoxOptions}
+     * @param disableReports True to disable automatic reporting of driver commands and tests, otherwise False.
+     * @param reportType     A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public FirefoxDriver(final FirefoxOptions options,
+                         final boolean disableReports,
+                         final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(null, null, options, null, null, disableReports, reportType);
     }
 
     /**
@@ -142,7 +217,34 @@ public class FirefoxDriver extends org.openqa.selenium.firefox.FirefoxDriver imp
                          final String projectName)
             throws InvalidTokenException, AgentConnectException, IOException,
             ObsoleteVersionException {
-        this(null, null, options, projectName, null, false);
+        this(null, null, options, projectName, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using default token and URL with Project name.
+     * <p>
+     * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param options     take a look at {@link FirefoxOptions}
+     * @param projectName Project name to report
+     * @param reportType  A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public FirefoxDriver(final FirefoxOptions options,
+                         final String projectName,
+                         final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(null, null, options, projectName, null, false, reportType);
     }
 
     /**
@@ -169,7 +271,36 @@ public class FirefoxDriver extends org.openqa.selenium.firefox.FirefoxDriver imp
                          final String jobName)
             throws InvalidTokenException, AgentConnectException, IOException,
             ObsoleteVersionException {
-        this(null, null, options, projectName, jobName, false);
+        this(null, null, options, projectName, jobName, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using default token and URL, Project and Job names.
+     * <p>
+     * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param options     take a look at {@link FirefoxOptions}
+     * @param projectName Project name to report
+     * @param jobName     Job name to report
+     * @param reportType  A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public FirefoxDriver(final FirefoxOptions options,
+                         final String projectName,
+                         final String jobName,
+                         final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(null, null, options, projectName, jobName, false, reportType);
     }
 
     /**
@@ -192,7 +323,32 @@ public class FirefoxDriver extends org.openqa.selenium.firefox.FirefoxDriver imp
                          final FirefoxOptions options)
             throws InvalidTokenException, AgentConnectException, IOException,
             ObsoleteVersionException {
-        this(null, token, options, null, null, false);
+        this(null, token, options, null, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided token and default URL.
+     * <p>
+     * Default Agent URL can be set using <em>TP_AGENT_URL</em> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param token      Development token that should be obtained from
+     *                   <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param options    take a look at {@link FirefoxOptions}
+     * @param reportType A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public FirefoxDriver(final String token,
+                         final FirefoxOptions options,
+                         final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(null, token, options, null, null, false, reportType);
     }
 
     /**
@@ -217,7 +373,34 @@ public class FirefoxDriver extends org.openqa.selenium.firefox.FirefoxDriver imp
                          final String projectName)
             throws InvalidTokenException, AgentConnectException, IOException,
             ObsoleteVersionException {
-        this(null, token, options, projectName, null, false);
+        this(null, token, options, projectName, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided token and default URL and Project name.
+     * <p>
+     * Default Agent URL can be set using <em>TP_AGENT_URL</em> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param token       Development token that should be obtained from
+     *                    <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param options     take a look at {@link FirefoxOptions}
+     * @param projectName Project name to report
+     * @param reportType  A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public FirefoxDriver(final String token,
+                         final FirefoxOptions options,
+                         final String projectName,
+                         final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(null, token, options, projectName, null, false, reportType);
     }
 
     /**
@@ -244,7 +427,36 @@ public class FirefoxDriver extends org.openqa.selenium.firefox.FirefoxDriver imp
                          final String jobName)
             throws InvalidTokenException, AgentConnectException, IOException,
             ObsoleteVersionException {
-        this(null, token, options, projectName, jobName, false);
+        this(null, token, options, projectName, jobName, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided token and default URL, Project and Job names.
+     * <p>
+     * Default Agent URL can be set using <em>TP_AGENT_URL</em> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param token       Development token that should be obtained from
+     *                    <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param options     take a look at {@link FirefoxOptions}
+     * @param projectName Project name to report
+     * @param jobName     Job name to report
+     * @param reportType  A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public FirefoxDriver(final String token,
+                         final FirefoxOptions options,
+                         final String projectName,
+                         final String jobName,
+                         final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(null, token, options, projectName, jobName, false, reportType);
     }
 
     /**
@@ -266,7 +478,31 @@ public class FirefoxDriver extends org.openqa.selenium.firefox.FirefoxDriver imp
                          final FirefoxOptions options)
             throws InvalidTokenException, AgentConnectException, IOException,
             ObsoleteVersionException {
-        this(remoteAddress, null, options, null, null, false);
+        this(remoteAddress, null, options, null, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided Agent URL and default token.
+     * <p>
+     * Default token can be set using <em>TP_DEV_TOKEN</em> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param remoteAddress Agent API base URL (e.g. http://localhost:8585/)
+     * @param options       take a look at {@link FirefoxOptions}
+     * @param reportType    A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public FirefoxDriver(final URL remoteAddress,
+                         final FirefoxOptions options,
+                         final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(remoteAddress, null, options, null, null, false, reportType);
     }
 
     /**
@@ -290,7 +526,33 @@ public class FirefoxDriver extends org.openqa.selenium.firefox.FirefoxDriver imp
                          final String projectName)
             throws InvalidTokenException, AgentConnectException, IOException,
             ObsoleteVersionException {
-        this(remoteAddress, null, options, projectName, null, false);
+        this(remoteAddress, null, options, projectName, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided Agent URL, default token and Project name.
+     * <p>
+     * Default token can be set using <em>TP_DEV_TOKEN</em> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param remoteAddress Agent API base URL (e.g. http://localhost:8585/)
+     * @param options       take a look at {@link FirefoxOptions}
+     * @param projectName   Project name to report
+     * @param reportType    A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public FirefoxDriver(final URL remoteAddress,
+                         final FirefoxOptions options,
+                         final String projectName,
+                         final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(remoteAddress, null, options, projectName, null, false, reportType);
     }
 
     /**
@@ -316,7 +578,35 @@ public class FirefoxDriver extends org.openqa.selenium.firefox.FirefoxDriver imp
                          final String jobName)
             throws InvalidTokenException, AgentConnectException, IOException,
             ObsoleteVersionException {
-        this(remoteAddress, null, options, projectName, jobName, false);
+        this(remoteAddress, null, options, projectName, jobName, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided Agent URL and default token, Project and Job names.
+     * <p>
+     * Default token can be set using <em>TP_DEV_TOKEN</em> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param remoteAddress Agent API base URL (e.g. http://localhost:8585/)
+     * @param options       take a look at {@link FirefoxOptions}
+     * @param projectName   Project name to report
+     * @param jobName       Job name to report
+     * @param reportType    A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public FirefoxDriver(final URL remoteAddress,
+                         final FirefoxOptions options,
+                         final String projectName,
+                         final String jobName,
+                         final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(remoteAddress, null, options, projectName, jobName, false, reportType);
     }
 
     /**
@@ -336,7 +626,29 @@ public class FirefoxDriver extends org.openqa.selenium.firefox.FirefoxDriver imp
                          final FirefoxOptions options)
             throws InvalidTokenException, AgentConnectException, IOException,
             ObsoleteVersionException {
-        this(remoteAddress, token, options, null, null, false);
+        this(remoteAddress, token, options, null, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided Agent URL and token.
+     *
+     * @param remoteAddress Agent API base URL (e.g. http://localhost:8585/)
+     * @param token         Development token that should be obtained from
+     *                      <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param options       take a look at {@link FirefoxOptions}
+     * @param reportType    A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public FirefoxDriver(final URL remoteAddress,
+                         final String token,
+                         final FirefoxOptions options,
+                         final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(remoteAddress, token, options, null, null, false, reportType);
     }
 
     /**
@@ -349,6 +661,7 @@ public class FirefoxDriver extends org.openqa.selenium.firefox.FirefoxDriver imp
      * @param projectName    Project name to report
      * @param jobName        Job name to report
      * @param disableReports True to disable automatic reporting of driver commands and tests, otherwise False.
+     * @param reportType     A type of report to produce - cloud, local or both.
      * @throws AgentConnectException    if Agent is not responding or responds with an error
      * @throws InvalidTokenException    if the token provided is invalid
      * @throws IOException              if the Agent API base URL provided is malformed
@@ -359,12 +672,13 @@ public class FirefoxDriver extends org.openqa.selenium.firefox.FirefoxDriver imp
                          final FirefoxOptions options,
                          final String projectName,
                          final String jobName,
-                         final boolean disableReports)
+                         final boolean disableReports,
+                         final ReportType reportType)
             throws InvalidTokenException, AgentConnectException, IOException,
             ObsoleteVersionException {
         super(new FakeDriverService(), new FirefoxOptions(AgentClient
                 .getClient(remoteAddress, token, options,
-                        new ReportSettings(projectName, jobName), disableReports)
+                        new ReportSettings(projectName, jobName, reportType), disableReports)
                 .getSession().getCapabilities()));
 
         this.reporter = new Reporter(this, AgentClient.getClient(this.getCapabilities()));

--- a/src/main/java/io/testproject/sdk/drivers/web/InternetExplorerDriver.java
+++ b/src/main/java/io/testproject/sdk/drivers/web/InternetExplorerDriver.java
@@ -20,6 +20,7 @@ package io.testproject.sdk.drivers.web;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.testproject.sdk.drivers.ReportType;
 import io.testproject.sdk.drivers.ReportingDriver;
 import io.testproject.sdk.internal.exceptions.AgentConnectException;
 import io.testproject.sdk.internal.exceptions.InvalidTokenException;
@@ -73,12 +74,35 @@ public class InternetExplorerDriver extends org.openqa.selenium.ie.InternetExplo
      * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
      * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
      * <p>
+     *
      * @throws AgentConnectException    if Agent is not responding or responds with an error
      * @throws InvalidTokenException    if the token provided is invalid
      * @throws MalformedURLException    if the Agent API base URL provided is malformed
      * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
      */
     public InternetExplorerDriver()
+            throws InvalidTokenException, AgentConnectException, MalformedURLException,
+            ObsoleteVersionException {
+        this(null, null, new InternetExplorerOptions());
+    }
+
+    /**
+     * Initiates a new session with the Agent using default token and URL.
+     * <p>
+     * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     *
+     * @param reportType A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public InternetExplorerDriver(final ReportType reportType)
             throws InvalidTokenException, AgentConnectException, MalformedURLException,
             ObsoleteVersionException {
         this(null, null, new InternetExplorerOptions());
@@ -118,6 +142,30 @@ public class InternetExplorerDriver extends org.openqa.selenium.ie.InternetExplo
      * <p>
      * Creates a new instance based on {@code capabilities}.
      *
+     * @param options    take a look at {@link InternetExplorerOptions}
+     * @param reportType A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public InternetExplorerDriver(final InternetExplorerOptions options, final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, MalformedURLException,
+            ObsoleteVersionException {
+        this(null, null, options, reportType);
+    }
+
+    /**
+     * Initiates a new session with the Agent using default token and URL.
+     * <p>
+     * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
      * @param options        take a look at {@link InternetExplorerOptions}
      * @param disableReports True to disable automatic reporting of driver commands and tests, otherwise False.
      * @throws AgentConnectException    if Agent is not responding or responds with an error
@@ -129,7 +177,34 @@ public class InternetExplorerDriver extends org.openqa.selenium.ie.InternetExplo
                                   final boolean disableReports)
             throws InvalidTokenException, AgentConnectException, MalformedURLException,
             ObsoleteVersionException {
-        this(null, null, options, null, null, disableReports);
+        this(null, null, options, null, null, disableReports, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using default token and URL.
+     * <p>
+     * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param options        take a look at {@link InternetExplorerOptions}
+     * @param disableReports True to disable automatic reporting of driver commands and tests, otherwise False.
+     * @param reportType     A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public InternetExplorerDriver(final InternetExplorerOptions options,
+                                  final boolean disableReports,
+                                  final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, MalformedURLException,
+            ObsoleteVersionException {
+        this(null, null, options, null, null, disableReports, reportType);
     }
 
     /**
@@ -154,7 +229,34 @@ public class InternetExplorerDriver extends org.openqa.selenium.ie.InternetExplo
                                   final String projectName)
             throws InvalidTokenException, AgentConnectException, MalformedURLException,
             ObsoleteVersionException {
-        this(null, null, options, projectName, null, false);
+        this(null, null, options, projectName, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using default token and URL with Project name.
+     * <p>
+     * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param options     take a look at {@link InternetExplorerOptions}
+     * @param projectName Project name to report
+     * @param reportType  A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public InternetExplorerDriver(final InternetExplorerOptions options,
+                                  final String projectName,
+                                  final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, MalformedURLException,
+            ObsoleteVersionException {
+        this(null, null, options, projectName, null, false, reportType);
     }
 
     /**
@@ -181,7 +283,36 @@ public class InternetExplorerDriver extends org.openqa.selenium.ie.InternetExplo
                                   final String jobName)
             throws InvalidTokenException, AgentConnectException, MalformedURLException,
             ObsoleteVersionException {
-        this(null, null, options, projectName, jobName, false);
+        this(null, null, options, projectName, jobName, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using default token and URL, Project and Job names.
+     * <p>
+     * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param options     take a look at {@link InternetExplorerOptions}
+     * @param projectName Project name to report
+     * @param jobName     Job name to report
+     * @param reportType  A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public InternetExplorerDriver(final InternetExplorerOptions options,
+                                  final String projectName,
+                                  final String jobName,
+                                  final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, MalformedURLException,
+            ObsoleteVersionException {
+        this(null, null, options, projectName, jobName, false, reportType);
     }
 
     /**
@@ -204,7 +335,32 @@ public class InternetExplorerDriver extends org.openqa.selenium.ie.InternetExplo
                                   final InternetExplorerOptions options)
             throws InvalidTokenException, AgentConnectException, MalformedURLException,
             ObsoleteVersionException {
-        this(null, token, options, null, null, false);
+        this(null, token, options, null, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided token and default URL.
+     * <p>
+     * Default Agent URL can be set using <em>TP_AGENT_URL</em> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param token      Development token that should be obtained from
+     *                   <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param options    take a look at {@link InternetExplorerOptions}
+     * @param reportType A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public InternetExplorerDriver(final String token,
+                                  final InternetExplorerOptions options,
+                                  final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, MalformedURLException,
+            ObsoleteVersionException {
+        this(null, token, options, null, null, false, reportType);
     }
 
     /**
@@ -229,7 +385,34 @@ public class InternetExplorerDriver extends org.openqa.selenium.ie.InternetExplo
                                   final String projectName)
             throws InvalidTokenException, AgentConnectException, MalformedURLException,
             ObsoleteVersionException {
-        this(null, token, options, projectName, null, false);
+        this(null, token, options, projectName, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using default token and URL with Project name.
+     * <p>
+     * Default Agent URL can be set using <em>TP_AGENT_URL</em> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param token       Development token that should be obtained from
+     *                    <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param options     take a look at {@link InternetExplorerOptions}
+     * @param projectName Project name to report
+     * @param reportType  A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public InternetExplorerDriver(final String token,
+                                  final InternetExplorerOptions options,
+                                  final String projectName,
+                                  final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, MalformedURLException,
+            ObsoleteVersionException {
+        this(null, token, options, projectName, null, false, reportType);
     }
 
     /**
@@ -256,7 +439,36 @@ public class InternetExplorerDriver extends org.openqa.selenium.ie.InternetExplo
                                   final String jobName)
             throws InvalidTokenException, AgentConnectException, MalformedURLException,
             ObsoleteVersionException {
-        this(null, token, options, projectName, jobName, false);
+        this(null, token, options, projectName, jobName, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided token and default URL, Project and Job names.
+     * <p>
+     * Default Agent URL can be set using <em>TP_AGENT_URL</em> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param token       Development token that should be obtained from
+     *                    <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param options     take a look at {@link InternetExplorerOptions}
+     * @param projectName Project name to report
+     * @param jobName     Job name to report
+     * @param reportType  A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public InternetExplorerDriver(final String token,
+                                  final InternetExplorerOptions options,
+                                  final String projectName,
+                                  final String jobName,
+                                  final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, MalformedURLException,
+            ObsoleteVersionException {
+        this(null, token, options, projectName, jobName, false, reportType);
     }
 
     /**
@@ -277,7 +489,31 @@ public class InternetExplorerDriver extends org.openqa.selenium.ie.InternetExplo
     public InternetExplorerDriver(final URL remoteAddress, final InternetExplorerOptions options)
             throws InvalidTokenException, AgentConnectException, MalformedURLException,
             ObsoleteVersionException {
-        this(remoteAddress, null, options, null, null, false);
+        this(remoteAddress, null, options, null, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided Agent URL and default token.
+     * <p>
+     * Default token can be set using <em>TP_DEV_TOKEN</em> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param remoteAddress Agent API base URL (e.g. http://localhost:8585/)
+     * @param options       take a look at {@link InternetExplorerOptions}
+     * @param reportType    A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public InternetExplorerDriver(final URL remoteAddress,
+                                  final InternetExplorerOptions options,
+                                  final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, MalformedURLException,
+            ObsoleteVersionException {
+        this(remoteAddress, null, options, null, null, false, reportType);
     }
 
     /**
@@ -301,7 +537,33 @@ public class InternetExplorerDriver extends org.openqa.selenium.ie.InternetExplo
                                   final String projectName)
             throws InvalidTokenException, AgentConnectException, MalformedURLException,
             ObsoleteVersionException {
-        this(remoteAddress, null, options, projectName, null, false);
+        this(remoteAddress, null, options, projectName, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided token and default URL and Project name.
+     * <p>
+     * Default token can be set using <em>TP_DEV_TOKEN</em> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param remoteAddress Agent API base URL (e.g. http://localhost:8585/)
+     * @param options       take a look at {@link InternetExplorerOptions}
+     * @param projectName   Project name to report
+     * @param reportType    A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public InternetExplorerDriver(final URL remoteAddress,
+                                  final InternetExplorerOptions options,
+                                  final String projectName,
+                                  final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, MalformedURLException,
+            ObsoleteVersionException {
+        this(remoteAddress, null, options, projectName, null, false, reportType);
     }
 
     /**
@@ -327,7 +589,35 @@ public class InternetExplorerDriver extends org.openqa.selenium.ie.InternetExplo
                                   final String jobName)
             throws InvalidTokenException, AgentConnectException, MalformedURLException,
             ObsoleteVersionException {
-        this(remoteAddress, null, options, projectName, jobName, false);
+        this(remoteAddress, null, options, projectName, jobName, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided Agent URL and default token, Project and Job names.
+     * <p>
+     * Default token can be set using <em>TP_DEV_TOKEN</em> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param remoteAddress Agent API base URL (e.g. http://localhost:8585/)
+     * @param options       take a look at {@link InternetExplorerOptions}
+     * @param projectName   Project name to report
+     * @param jobName       Job name to report
+     * @param reportType    A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public InternetExplorerDriver(final URL remoteAddress,
+                                  final InternetExplorerOptions options,
+                                  final String projectName,
+                                  final String jobName,
+                                  final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, MalformedURLException,
+            ObsoleteVersionException {
+        this(remoteAddress, null, options, projectName, jobName, false, reportType);
     }
 
     /**
@@ -347,7 +637,29 @@ public class InternetExplorerDriver extends org.openqa.selenium.ie.InternetExplo
                                   final InternetExplorerOptions options)
             throws InvalidTokenException, AgentConnectException, MalformedURLException,
             ObsoleteVersionException {
-        this(remoteAddress, token, options, null, null, false);
+        this(remoteAddress, token, options, null, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided Agent URL and token.
+     *
+     * @param remoteAddress Agent API base URL (e.g. http://localhost:8585/)
+     * @param token         Development token that should be obtained from
+     *                      <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param options       take a look at {@link InternetExplorerOptions}
+     * @param reportType    A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public InternetExplorerDriver(final URL remoteAddress,
+                                  final String token,
+                                  final InternetExplorerOptions options,
+                                  final ReportType reportType)
+            throws InvalidTokenException, AgentConnectException, MalformedURLException,
+            ObsoleteVersionException {
+        this(remoteAddress, token, options, null, null, false, reportType);
     }
 
     /**
@@ -360,6 +672,7 @@ public class InternetExplorerDriver extends org.openqa.selenium.ie.InternetExplo
      * @param projectName    Project name to report
      * @param jobName        Job name to report
      * @param disableReports True to disable automatic reporting of driver commands and tests, otherwise False.
+     * @param reportType     A type of report to produce - cloud, local or both.
      * @throws AgentConnectException    if Agent is not responding or responds with an error
      * @throws InvalidTokenException    if the token provided is invalid
      * @throws MalformedURLException    if the Agent API base URL provided is malformed
@@ -370,11 +683,13 @@ public class InternetExplorerDriver extends org.openqa.selenium.ie.InternetExplo
                                   final InternetExplorerOptions options,
                                   final String projectName,
                                   final String jobName,
-                                  final boolean disableReports)
+                                  final boolean disableReports,
+                                  final ReportType reportType)
             throws InvalidTokenException, AgentConnectException, MalformedURLException,
             ObsoleteVersionException {
         super(fakeDriverService(), new InternetExplorerOptions().merge(AgentClient
-                .getClient(remoteAddress, token, options, new ReportSettings(projectName, jobName), disableReports)
+                .getClient(remoteAddress, token, options,
+                        new ReportSettings(projectName, jobName, reportType), disableReports)
                 .getSession().getCapabilities()));
 
         this.reporter = new Reporter(this, AgentClient.getClient(this.getCapabilities()));
@@ -434,7 +749,6 @@ public class InternetExplorerDriver extends org.openqa.selenium.ie.InternetExplo
     }
 
     /**
-     *
      * Creates fake DriverService to avoid searching for driver executable.
      *
      * @return a new DriverService with dummy data.

--- a/src/main/java/io/testproject/sdk/drivers/web/RemoteWebDriver.java
+++ b/src/main/java/io/testproject/sdk/drivers/web/RemoteWebDriver.java
@@ -18,6 +18,7 @@
 package io.testproject.sdk.drivers.web;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.testproject.sdk.drivers.ReportType;
 import io.testproject.sdk.drivers.ReportingDriver;
 import io.testproject.sdk.internal.exceptions.AgentConnectException;
 import io.testproject.sdk.internal.exceptions.InvalidTokenException;
@@ -69,7 +70,31 @@ public class RemoteWebDriver extends org.openqa.selenium.remote.RemoteWebDriver 
     public RemoteWebDriver(final Capabilities capabilities)
             throws AgentConnectException, InvalidTokenException, MalformedURLException,
             ObsoleteVersionException {
-        this(null, null, capabilities);
+        this(null, null, capabilities, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using default token and URL.
+     * <p>
+     * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param capabilities take a look at {@link Capabilities}
+     * @param reportType   A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public RemoteWebDriver(final Capabilities capabilities, final ReportType reportType)
+            throws AgentConnectException, InvalidTokenException, MalformedURLException,
+            ObsoleteVersionException {
+        this(null, null, capabilities, reportType);
     }
 
     /**
@@ -94,7 +119,34 @@ public class RemoteWebDriver extends org.openqa.selenium.remote.RemoteWebDriver 
                            final boolean disableReports)
             throws AgentConnectException, InvalidTokenException, MalformedURLException,
             ObsoleteVersionException {
-        this(null, null, capabilities, null, null, disableReports);
+        this(null, null, capabilities, null, null, disableReports, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using default token and URL.
+     * <p>
+     * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param capabilities   take a look at {@link Capabilities}
+     * @param disableReports True to disable automatic reporting of driver commands and tests, otherwise False.
+     * @param reportType     A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public RemoteWebDriver(final Capabilities capabilities,
+                           final boolean disableReports,
+                           final ReportType reportType)
+            throws AgentConnectException, InvalidTokenException, MalformedURLException,
+            ObsoleteVersionException {
+        this(null, null, capabilities, null, null, disableReports, reportType);
     }
 
     /**
@@ -119,7 +171,34 @@ public class RemoteWebDriver extends org.openqa.selenium.remote.RemoteWebDriver 
                            final String projectName)
             throws AgentConnectException, InvalidTokenException, MalformedURLException,
             ObsoleteVersionException {
-        this(null, null, capabilities, projectName, null, false);
+        this(null, null, capabilities, projectName, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using default token and URL with Project name.
+     * <p>
+     * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param capabilities take a look at {@link Capabilities}
+     * @param projectName  Project name to report
+     * @param reportType   A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public RemoteWebDriver(final Capabilities capabilities,
+                           final String projectName,
+                           final ReportType reportType)
+            throws AgentConnectException, InvalidTokenException, MalformedURLException,
+            ObsoleteVersionException {
+        this(null, null, capabilities, projectName, null, false, reportType);
     }
 
     /**
@@ -146,7 +225,36 @@ public class RemoteWebDriver extends org.openqa.selenium.remote.RemoteWebDriver 
                            final String jobName)
             throws AgentConnectException, InvalidTokenException, MalformedURLException,
             ObsoleteVersionException {
-        this(null, null, capabilities, projectName, jobName, false);
+        this(null, null, capabilities, projectName, jobName, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using default token and URL, Project and Job names.
+     * <p>
+     * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param capabilities take a look at {@link Capabilities}
+     * @param projectName  Project name to report
+     * @param jobName      Job name to report
+     * @param reportType   A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public RemoteWebDriver(final Capabilities capabilities,
+                           final String projectName,
+                           final String jobName,
+                           final ReportType reportType)
+            throws AgentConnectException, InvalidTokenException, MalformedURLException,
+            ObsoleteVersionException {
+        this(null, null, capabilities, projectName, jobName, false, reportType);
     }
 
     /**
@@ -169,7 +277,32 @@ public class RemoteWebDriver extends org.openqa.selenium.remote.RemoteWebDriver 
                            final Capabilities capabilities)
             throws AgentConnectException, InvalidTokenException, MalformedURLException,
             ObsoleteVersionException {
-        this(null, token, capabilities, null, null, false);
+        this(null, token, capabilities, null, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided token and default URL.
+     * <p>
+     * Default Agent URL can be set using <em>TP_AGENT_URL</em> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param token        Development token that should be obtained from
+     *                     <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param capabilities take a look at {@link Capabilities}
+     * @param reportType   A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public RemoteWebDriver(final String token,
+                           final Capabilities capabilities,
+                           final ReportType reportType)
+            throws AgentConnectException, InvalidTokenException, MalformedURLException,
+            ObsoleteVersionException {
+        this(null, token, capabilities, null, null, false, reportType);
     }
 
     /**
@@ -194,7 +327,34 @@ public class RemoteWebDriver extends org.openqa.selenium.remote.RemoteWebDriver 
                            final String projectName)
             throws AgentConnectException, InvalidTokenException, MalformedURLException,
             ObsoleteVersionException {
-        this(null, token, capabilities, projectName, null, false);
+        this(null, token, capabilities, projectName, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided token and default URL and Project name.
+     * <p>
+     * Default Agent URL can be set using <em>TP_AGENT_URL</em> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param token        Development token that should be obtained from
+     *                     <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param capabilities take a look at {@link Capabilities}
+     * @param projectName  Project name to report
+     * @param reportType   A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public RemoteWebDriver(final String token,
+                           final Capabilities capabilities,
+                           final String projectName,
+                           final ReportType reportType)
+            throws AgentConnectException, InvalidTokenException, MalformedURLException,
+            ObsoleteVersionException {
+        this(null, token, capabilities, projectName, null, false, reportType);
     }
 
     /**
@@ -221,7 +381,36 @@ public class RemoteWebDriver extends org.openqa.selenium.remote.RemoteWebDriver 
                            final String jobName)
             throws AgentConnectException, InvalidTokenException, MalformedURLException,
             ObsoleteVersionException {
-        this(null, token, capabilities, projectName, jobName, false);
+        this(null, token, capabilities, projectName, jobName, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided token and default URL, Project and Job names.
+     * <p>
+     * Default Agent URL can be set using <em>TP_AGENT_URL</em> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param token        Development token that should be obtained from
+     *                     <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param capabilities take a look at {@link Capabilities}
+     * @param projectName  Project name to report
+     * @param jobName      Job name to report
+     * @param reportType   A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public RemoteWebDriver(final String token,
+                           final Capabilities capabilities,
+                           final String projectName,
+                           final String jobName,
+                           final ReportType reportType)
+            throws AgentConnectException, InvalidTokenException, MalformedURLException,
+            ObsoleteVersionException {
+        this(null, token, capabilities, projectName, jobName, false, reportType);
     }
 
     /**
@@ -243,7 +432,31 @@ public class RemoteWebDriver extends org.openqa.selenium.remote.RemoteWebDriver 
                            final Capabilities capabilities)
             throws AgentConnectException, InvalidTokenException, MalformedURLException,
             ObsoleteVersionException {
-        this(remoteAddress, null, capabilities, null, null, false);
+        this(remoteAddress, null, capabilities, null, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided Agent URL and default token.
+     * <p>
+     * Default token can be set using <em>TP_DEV_TOKEN</em> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param remoteAddress Agent API base URL (e.g. http://localhost:8585/)
+     * @param capabilities  take a look at {@link Capabilities}
+     * @param reportType    A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public RemoteWebDriver(final URL remoteAddress,
+                           final Capabilities capabilities,
+                           final ReportType reportType)
+            throws AgentConnectException, InvalidTokenException, MalformedURLException,
+            ObsoleteVersionException {
+        this(remoteAddress, null, capabilities, null, null, false, reportType);
     }
 
     /**
@@ -267,7 +480,33 @@ public class RemoteWebDriver extends org.openqa.selenium.remote.RemoteWebDriver 
                            final String projectName)
             throws AgentConnectException, InvalidTokenException, MalformedURLException,
             ObsoleteVersionException {
-        this(remoteAddress, null, capabilities, projectName, null, false);
+        this(remoteAddress, null, capabilities, projectName, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided Agent URL, default token and Project name.
+     * <p>
+     * Default token can be set using <em>TP_DEV_TOKEN</em> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param remoteAddress Agent API base URL (e.g. http://localhost:8585/)
+     * @param capabilities  take a look at {@link Capabilities}
+     * @param projectName   Project name to report
+     * @param reportType    A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public RemoteWebDriver(final URL remoteAddress,
+                           final Capabilities capabilities,
+                           final String projectName,
+                           final ReportType reportType)
+            throws AgentConnectException, InvalidTokenException, MalformedURLException,
+            ObsoleteVersionException {
+        this(remoteAddress, null, capabilities, projectName, null, false, reportType);
     }
 
     /**
@@ -293,7 +532,35 @@ public class RemoteWebDriver extends org.openqa.selenium.remote.RemoteWebDriver 
                            final String jobName)
             throws AgentConnectException, InvalidTokenException, MalformedURLException,
             ObsoleteVersionException {
-        this(remoteAddress, null, capabilities, projectName, jobName, false);
+        this(remoteAddress, null, capabilities, projectName, jobName, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided Agent URL and default token, Project and Job names.
+     * <p>
+     * Default token can be set using <em>TP_DEV_TOKEN</em> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param remoteAddress Agent API base URL (e.g. http://localhost:8585/)
+     * @param capabilities  take a look at {@link Capabilities}
+     * @param projectName   Project name to report
+     * @param jobName       Job name to report
+     * @param reportType    A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public RemoteWebDriver(final URL remoteAddress,
+                           final Capabilities capabilities,
+                           final String projectName,
+                           final String jobName,
+                           final ReportType reportType)
+            throws AgentConnectException, InvalidTokenException, MalformedURLException,
+            ObsoleteVersionException {
+        this(remoteAddress, null, capabilities, projectName, jobName, false, reportType);
     }
 
     /**
@@ -313,7 +580,29 @@ public class RemoteWebDriver extends org.openqa.selenium.remote.RemoteWebDriver 
                            final Capabilities capabilities)
             throws AgentConnectException, InvalidTokenException, MalformedURLException,
             ObsoleteVersionException {
-        this(remoteAddress, token, capabilities, null, null, false);
+        this(remoteAddress, token, capabilities, null, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided Agent URL and token.
+     *
+     * @param remoteAddress Agent API base URL (e.g. http://localhost:8585/)
+     * @param token         Development token that should be obtained from
+     *                      <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param capabilities  take a look at {@link Capabilities}
+     * @param reportType    A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public RemoteWebDriver(final URL remoteAddress,
+                           final String token,
+                           final Capabilities capabilities,
+                           final ReportType reportType)
+            throws AgentConnectException, InvalidTokenException, MalformedURLException,
+            ObsoleteVersionException {
+        this(remoteAddress, token, capabilities, null, null, false, reportType);
     }
 
     /**
@@ -326,6 +615,7 @@ public class RemoteWebDriver extends org.openqa.selenium.remote.RemoteWebDriver 
      * @param projectName    Project name to report
      * @param jobName        Job name to report
      * @param disableReports True to disable automatic reporting of driver commands and tests, otherwise False.
+     * @param reportType     A type of report to produce - cloud, local or both.
      * @throws AgentConnectException    if Agent is not responding or responds with an error
      * @throws InvalidTokenException    if the token provided is invalid
      * @throws MalformedURLException    if the Agent API base URL provided is malformed
@@ -336,11 +626,12 @@ public class RemoteWebDriver extends org.openqa.selenium.remote.RemoteWebDriver 
                            final Capabilities capabilities,
                            final String projectName,
                            final String jobName,
-                           final boolean disableReports)
+                           final boolean disableReports,
+                           final ReportType reportType)
             throws AgentConnectException, InvalidTokenException, MalformedURLException,
             ObsoleteVersionException {
         super(AgentClient.getClient(remoteAddress, token, capabilities,
-                new ReportSettings(projectName, jobName), disableReports)
+                new ReportSettings(projectName, jobName, reportType), disableReports)
                 .getSession().getCapabilities());
 
         this.reporter = new Reporter(this, AgentClient.getClient(this.getCapabilities()));

--- a/src/main/java/io/testproject/sdk/drivers/web/SafariDriver.java
+++ b/src/main/java/io/testproject/sdk/drivers/web/SafariDriver.java
@@ -18,6 +18,7 @@
 package io.testproject.sdk.drivers.web;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.testproject.sdk.drivers.ReportType;
 import io.testproject.sdk.drivers.ReportingDriver;
 import io.testproject.sdk.internal.exceptions.AgentConnectException;
 import io.testproject.sdk.internal.exceptions.InvalidTokenException;
@@ -59,6 +60,7 @@ public class SafariDriver extends org.openqa.selenium.safari.SafariDriver implem
      * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
      * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
      * <p>
+     *
      * @throws AgentConnectException    if Agent is not responding or responds with an error
      * @throws InvalidTokenException    if the token provided is invalid
      * @throws MalformedURLException    if the Agent API base URL provided is malformed
@@ -68,6 +70,28 @@ public class SafariDriver extends org.openqa.selenium.safari.SafariDriver implem
             throws AgentConnectException, InvalidTokenException, MalformedURLException,
             ObsoleteVersionException {
         this(null, null, new SafariOptions());
+    }
+
+    /**
+     * Initiates a new session with the Agent using default token and URL.
+     * <p>
+     * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     *
+     * @param reportType A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public SafariDriver(final ReportType reportType)
+            throws AgentConnectException, InvalidTokenException, MalformedURLException,
+            ObsoleteVersionException {
+        this(null, null, new SafariOptions(), reportType);
     }
 
     /**
@@ -104,6 +128,30 @@ public class SafariDriver extends org.openqa.selenium.safari.SafariDriver implem
      * <p>
      * Creates a new instance based on {@code capabilities}.
      *
+     * @param options    take a look at {@link SafariOptions}
+     * @param reportType A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public SafariDriver(final SafariOptions options, final ReportType reportType)
+            throws AgentConnectException, InvalidTokenException, MalformedURLException,
+            ObsoleteVersionException {
+        this(null, null, options, reportType);
+    }
+
+    /**
+     * Initiates a new session with the Agent using default token and URL.
+     * <p>
+     * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
      * @param options        take a look at {@link SafariOptions}
      * @param disableReports True to disable automatic reporting of driver commands and tests, otherwise False.
      * @throws AgentConnectException    if Agent is not responding or responds with an error
@@ -115,7 +163,34 @@ public class SafariDriver extends org.openqa.selenium.safari.SafariDriver implem
                         final boolean disableReports)
             throws AgentConnectException, InvalidTokenException, MalformedURLException,
             ObsoleteVersionException {
-        this(null, null, options, null, null, disableReports);
+        this(null, null, options, null, null, disableReports, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using default token and URL.
+     * <p>
+     * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param options        take a look at {@link SafariOptions}
+     * @param disableReports True to disable automatic reporting of driver commands and tests, otherwise False.
+     * @param reportType     A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public SafariDriver(final SafariOptions options,
+                        final boolean disableReports,
+                        final ReportType reportType)
+            throws AgentConnectException, InvalidTokenException, MalformedURLException,
+            ObsoleteVersionException {
+        this(null, null, options, null, null, disableReports, reportType);
     }
 
     /**
@@ -140,7 +215,34 @@ public class SafariDriver extends org.openqa.selenium.safari.SafariDriver implem
                         final String projectName)
             throws AgentConnectException, InvalidTokenException, MalformedURLException,
             ObsoleteVersionException {
-        this(null, null, options, projectName, null, false);
+        this(null, null, options, projectName, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using default token and URL with Project name.
+     * <p>
+     * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param options     take a look at {@link SafariOptions}
+     * @param projectName Project name to report
+     * @param reportType  A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public SafariDriver(final SafariOptions options,
+                        final String projectName,
+                        final ReportType reportType)
+            throws AgentConnectException, InvalidTokenException, MalformedURLException,
+            ObsoleteVersionException {
+        this(null, null, options, projectName, null, false, reportType);
     }
 
     /**
@@ -167,7 +269,36 @@ public class SafariDriver extends org.openqa.selenium.safari.SafariDriver implem
                         final String jobName)
             throws AgentConnectException, InvalidTokenException, MalformedURLException,
             ObsoleteVersionException {
-        this(null, null, options, projectName, jobName, false);
+        this(null, null, options, projectName, jobName, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using default token and URL, Project and Job names.
+     * <p>
+     * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param options     take a look at {@link SafariOptions}
+     * @param projectName Project name to report
+     * @param jobName     Job name to report
+     * @param reportType  A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public SafariDriver(final SafariOptions options,
+                        final String projectName,
+                        final String jobName,
+                        final ReportType reportType)
+            throws AgentConnectException, InvalidTokenException, MalformedURLException,
+            ObsoleteVersionException {
+        this(null, null, options, projectName, jobName, false, reportType);
     }
 
     /**
@@ -190,7 +321,32 @@ public class SafariDriver extends org.openqa.selenium.safari.SafariDriver implem
                         final SafariOptions options)
             throws AgentConnectException, InvalidTokenException, MalformedURLException,
             ObsoleteVersionException {
-        this(null, token, options, null, null, false);
+        this(null, token, options, null, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided token and default URL.
+     * <p>
+     * Default Agent URL can be set using <em>TP_AGENT_URL</em> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param token      Development token that should be obtained from
+     *                   <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param options    take a look at {@link SafariOptions}
+     * @param reportType A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public SafariDriver(final String token,
+                        final SafariOptions options,
+                        final ReportType reportType)
+            throws AgentConnectException, InvalidTokenException, MalformedURLException,
+            ObsoleteVersionException {
+        this(null, token, options, null, null, false, reportType);
     }
 
     /**
@@ -215,7 +371,34 @@ public class SafariDriver extends org.openqa.selenium.safari.SafariDriver implem
                         final String projectName)
             throws AgentConnectException, InvalidTokenException, MalformedURLException,
             ObsoleteVersionException {
-        this(null, token, options, projectName, null, false);
+        this(null, token, options, projectName, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided token and default URL and Project name.
+     * <p>
+     * Default Agent URL can be set using <em>TP_AGENT_URL</em> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param token       Development token that should be obtained from
+     *                    <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param options     take a look at {@link SafariOptions}
+     * @param projectName Project name to report
+     * @param reportType  A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public SafariDriver(final String token,
+                        final SafariOptions options,
+                        final String projectName,
+                        final ReportType reportType)
+            throws AgentConnectException, InvalidTokenException, MalformedURLException,
+            ObsoleteVersionException {
+        this(null, token, options, projectName, null, false, reportType);
     }
 
     /**
@@ -242,7 +425,36 @@ public class SafariDriver extends org.openqa.selenium.safari.SafariDriver implem
                         final String jobName)
             throws AgentConnectException, InvalidTokenException, MalformedURLException,
             ObsoleteVersionException {
-        this(null, token, options, projectName, jobName, false);
+        this(null, token, options, projectName, jobName, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided token and default URL, Project and Job names.
+     * <p>
+     * Default Agent URL can be set using <em>TP_AGENT_URL</em> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param token       Development token that should be obtained from
+     *                    <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param options     take a look at {@link SafariOptions}
+     * @param projectName Project name to report
+     * @param jobName     Job name to report
+     * @param reportType  A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public SafariDriver(final String token,
+                        final SafariOptions options,
+                        final String projectName,
+                        final String jobName,
+                        final ReportType reportType)
+            throws AgentConnectException, InvalidTokenException, MalformedURLException,
+            ObsoleteVersionException {
+        this(null, token, options, projectName, jobName, false, reportType);
     }
 
     /**
@@ -264,7 +476,31 @@ public class SafariDriver extends org.openqa.selenium.safari.SafariDriver implem
                         final SafariOptions options)
             throws AgentConnectException, InvalidTokenException, MalformedURLException,
             ObsoleteVersionException {
-        this(remoteAddress, null, options, null, null, false);
+        this(remoteAddress, null, options, null, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided Agent URL and default token.
+     * <p>
+     * Default token can be set using <em>TP_DEV_TOKEN</em> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param remoteAddress Agent API base URL (e.g. http://localhost:8585/)
+     * @param options       take a look at {@link SafariOptions}
+     * @param reportType    A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public SafariDriver(final URL remoteAddress,
+                        final SafariOptions options,
+                        final ReportType reportType)
+            throws AgentConnectException, InvalidTokenException, MalformedURLException,
+            ObsoleteVersionException {
+        this(remoteAddress, null, options, null, null, false, reportType);
     }
 
     /**
@@ -288,7 +524,33 @@ public class SafariDriver extends org.openqa.selenium.safari.SafariDriver implem
                         final String projectName)
             throws AgentConnectException, InvalidTokenException, MalformedURLException,
             ObsoleteVersionException {
-        this(remoteAddress, null, options, projectName, null, false);
+        this(remoteAddress, null, options, projectName, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided Agent URL, default token and Project name.
+     * <p>
+     * Default token can be set using <em>TP_DEV_TOKEN</em> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param remoteAddress Agent API base URL (e.g. http://localhost:8585/)
+     * @param options       take a look at {@link SafariOptions}
+     * @param projectName   Project name to report
+     * @param reportType    A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public SafariDriver(final URL remoteAddress,
+                        final SafariOptions options,
+                        final String projectName,
+                        final ReportType reportType)
+            throws AgentConnectException, InvalidTokenException, MalformedURLException,
+            ObsoleteVersionException {
+        this(remoteAddress, null, options, projectName, null, false, reportType);
     }
 
     /**
@@ -314,7 +576,35 @@ public class SafariDriver extends org.openqa.selenium.safari.SafariDriver implem
                         final String jobName)
             throws AgentConnectException, InvalidTokenException, MalformedURLException,
             ObsoleteVersionException {
-        this(remoteAddress, null, options, projectName, jobName, false);
+        this(remoteAddress, null, options, projectName, jobName, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided Agent URL and default token, Project and Job names.
+     * <p>
+     * Default token can be set using <em>TP_DEV_TOKEN</em> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param remoteAddress Agent API base URL (e.g. http://localhost:8585/)
+     * @param options       take a look at {@link SafariOptions}
+     * @param projectName   Project name to report
+     * @param jobName       Job name to report
+     * @param reportType    A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public SafariDriver(final URL remoteAddress,
+                        final SafariOptions options,
+                        final String projectName,
+                        final String jobName,
+                        final ReportType reportType)
+            throws AgentConnectException, InvalidTokenException, MalformedURLException,
+            ObsoleteVersionException {
+        this(remoteAddress, null, options, projectName, jobName, false, reportType);
     }
 
     /**
@@ -334,7 +624,29 @@ public class SafariDriver extends org.openqa.selenium.safari.SafariDriver implem
                         final SafariOptions options)
             throws AgentConnectException, InvalidTokenException, MalformedURLException,
             ObsoleteVersionException {
-        this(remoteAddress, token, options, null, null, false);
+        this(remoteAddress, token, options, null, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided Agent URL and token.
+     *
+     * @param remoteAddress Agent API base URL (e.g. http://localhost:8585/)
+     * @param token         Development token that should be obtained from
+     *                      <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param options       take a look at {@link SafariOptions}
+     * @param reportType    A type of report to produce - cloud, local or both.
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public SafariDriver(final URL remoteAddress,
+                        final String token,
+                        final SafariOptions options,
+                        final ReportType reportType)
+            throws AgentConnectException, InvalidTokenException, MalformedURLException,
+            ObsoleteVersionException {
+        this(remoteAddress, token, options, null, null, false, reportType);
     }
 
     /**
@@ -347,6 +659,7 @@ public class SafariDriver extends org.openqa.selenium.safari.SafariDriver implem
      * @param projectName    Project name to report
      * @param jobName        Job name to report
      * @param disableReports True to disable automatic reporting of driver commands and tests, otherwise False.
+     * @param reportType     A type of report to produce - cloud, local or both.
      * @throws AgentConnectException    if Agent is not responding or responds with an error
      * @throws InvalidTokenException    if the token provided is invalid
      * @throws MalformedURLException    if the Agent API base URL provided is malformed
@@ -357,12 +670,13 @@ public class SafariDriver extends org.openqa.selenium.safari.SafariDriver implem
                         final SafariOptions options,
                         final String projectName,
                         final String jobName,
-                        final boolean disableReports)
+                        final boolean disableReports,
+                        final ReportType reportType)
             throws AgentConnectException, InvalidTokenException, MalformedURLException,
             ObsoleteVersionException {
         super(new SafariOptions(AgentClient
                 .getClient(remoteAddress, token, options,
-                        new ReportSettings(projectName, jobName), disableReports)
+                        new ReportSettings(projectName, jobName, reportType), disableReports)
                 .getSession().getCapabilities()));
 
         this.reporter = new Reporter(this, AgentClient.getClient(this.getCapabilities()));

--- a/src/main/java/io/testproject/sdk/internal/rest/AgentClient.java
+++ b/src/main/java/io/testproject/sdk/internal/rest/AgentClient.java
@@ -189,6 +189,11 @@ public final class AgentClient implements Closeable {
     private boolean skipInferring = false;
 
     /**
+     * Session initialization response.
+     */
+    private SessionResponse agentResponse;
+
+    /**
      * Creates a new instance of the class.
      * Initiates a development session with the Agent.
      *
@@ -651,7 +656,6 @@ public final class AgentClient implements Closeable {
 
         LOG.trace("Session initialization response: {}", responseBody);
 
-        SessionResponse agentResponse;
         try {
             agentResponse = GSON.fromJson(responseBody, SessionResponse.class);
         } catch (JsonSyntaxException e) {
@@ -935,6 +939,10 @@ public final class AgentClient implements Closeable {
         }
 
         LOG.info("Session [{}] closed", this.getSession().getSessionId());
+
+        if (!StringUtils.isEmpty(agentResponse.getLocalReport())) {
+            LOG.info("Execution Report: {}", agentResponse.getLocalReport());
+        }
     }
 
     /**

--- a/src/main/java/io/testproject/sdk/internal/rest/AgentClient.java
+++ b/src/main/java/io/testproject/sdk/internal/rest/AgentClient.java
@@ -750,11 +750,13 @@ public final class AgentClient implements Closeable {
         ReportSettings result;
         if (reportSettings != null) {
             // Explicitly provided names override inferred names
+            // Explicitly requested report type must be honored
             result = new ReportSettings(
                     !StringUtils.isEmpty(reportSettings.getProjectName())
                             ? reportSettings.getProjectName() : inferredReportSettings.getProjectName(),
                     !StringUtils.isEmpty(reportSettings.getJobName())
-                            ? reportSettings.getJobName() : inferredReportSettings.getJobName());
+                            ? reportSettings.getJobName() : inferredReportSettings.getJobName(),
+                    reportSettings.getReportType());
         } else {
             // Nothing provided, using only inferred names
             result = inferredReportSettings;

--- a/src/main/java/io/testproject/sdk/internal/rest/AgentClient.java
+++ b/src/main/java/io/testproject/sdk/internal/rest/AgentClient.java
@@ -18,6 +18,7 @@
 package io.testproject.sdk.internal.rest;
 
 import com.google.gson.*;
+import io.testproject.sdk.drivers.ReportType;
 import io.testproject.sdk.internal.addons.ActionProxy;
 import io.testproject.sdk.internal.exceptions.*;
 import io.testproject.sdk.internal.helpers.ShutdownThreadManager;
@@ -109,6 +110,11 @@ public final class AgentClient implements Closeable {
      * Minimum Agent version that support session reuse.
      */
     private static final String MIN_SESSION_REUSE_CAPABLE_VERSION = "0.64.32";
+
+    /**
+     * Minimum Agent version that supports local reports.
+     */
+    private static final String MIN_LOCAL_REPORT_SUPPORTED_VERSION = "2.1.0";
 
     /**
      * Logger instance.
@@ -242,6 +248,7 @@ public final class AgentClient implements Closeable {
 
         // Start Session
         ReportSettings sessionReportSettings = disableReports ? null : inferReportSettings(reportSettings);
+
         try {
             startSession(capabilities, sessionReportSettings);
         } catch (MissingBrowserException e) {
@@ -251,6 +258,9 @@ public final class AgentClient implements Closeable {
             throw new AgentConnectException(String.format("Requested device %s is not connected",
                     capabilities.getCapability("udid")), e);
         }
+
+        // Make sure local reports are supported
+        verifyLocalReportsSupported(reportSettings.getReportType());
 
         // Start reports queue
         if (!disableReports) {
@@ -770,6 +780,22 @@ public final class AgentClient implements Closeable {
         }
 
         return result;
+    }
+
+    /**
+     * Verify that target Agent supports local reports, otherwise throw an exception.
+     * @param reportType Report type requested.
+     * @throws AgentConnectException when local reports are not supported.
+     */
+    private void verifyLocalReportsSupported(final ReportType reportType) throws AgentConnectException {
+        if (reportType == ReportType.LOCAL && new ComparableVersion(version).compareTo(
+                new ComparableVersion(MIN_LOCAL_REPORT_SUPPORTED_VERSION)) < 0) {
+            StringBuilder message = new StringBuilder()
+                    .append("Target Agent version").append(" [").append(version).append("] ")
+                    .append("doesn't support local reports. ")
+                    .append("Upgrade the Agent to the latest version and try again.");
+            throw new AgentConnectException(message.toString());
+        }
     }
 
     /**

--- a/src/main/java/io/testproject/sdk/internal/rest/ReportSettings.java
+++ b/src/main/java/io/testproject/sdk/internal/rest/ReportSettings.java
@@ -17,6 +17,8 @@
 
 package io.testproject.sdk.internal.rest;
 
+import io.testproject.sdk.drivers.ReportType;
+
 import java.util.Objects;
 
 /**
@@ -32,6 +34,11 @@ public class ReportSettings {
      * Job name to report.
      */
     private final String jobName;
+
+    /**
+     * Report type = cloud, local ort both.
+     */
+    private ReportType reportType;
 
     /**
      * Getter for {@link #projectName} field.
@@ -52,6 +59,15 @@ public class ReportSettings {
     }
 
     /**
+     * Getter for {@link #reportType} field.
+     *
+     * @return value of {@link #reportType} field
+     */
+    public ReportType getReportType() {
+        return reportType;
+    }
+
+    /**
      * Creates a new instance of the class.
      *
      * @param projectName Project name to report
@@ -60,6 +76,20 @@ public class ReportSettings {
     public ReportSettings(final String projectName, final String jobName) {
         this.projectName = projectName;
         this.jobName = jobName;
+        this.reportType = ReportType.CLOUD_AND_LOCAL;
+    }
+
+    /**
+     * Creates a new instance of the class.
+     *
+     * @param projectName Project name to report
+     * @param jobName     Job name to report
+     * @param reportType  Report type to produce - cloud, local or both.
+     */
+    public ReportSettings(final String projectName, final String jobName, final ReportType reportType) {
+        this.projectName = projectName;
+        this.jobName = jobName;
+        this.reportType = reportType;
     }
 
     /**

--- a/src/main/java/io/testproject/sdk/internal/rest/messages/SessionRequest.java
+++ b/src/main/java/io/testproject/sdk/internal/rest/messages/SessionRequest.java
@@ -17,6 +17,7 @@
 
 package io.testproject.sdk.internal.rest.messages;
 
+import io.testproject.sdk.drivers.ReportType;
 import io.testproject.sdk.internal.rest.ReportSettings;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -51,6 +52,10 @@ public class SessionRequest {
      * Job name to report.
      */
     private String jobName;
+    /**
+     * Type of report to produce - cloud, local or both.
+     */
+    private ReportType reportType;
 
     /**
      * Creates a new instance using provided capabilities.
@@ -62,6 +67,7 @@ public class SessionRequest {
         if (reportSettings != null) {
             this.projectName = reportSettings.getProjectName();
             this.jobName = reportSettings.getJobName();
+            this.reportType = reportSettings.getReportType();
         }
 
         // Retrieves the version sent bu gradle when creating the JAR
@@ -132,5 +138,14 @@ public class SessionRequest {
      */
     public String getJobName() {
         return jobName;
+    }
+
+    /**
+     * Getter for {@link #reportType} field.
+     *
+     * @return value of {@link #reportType} field
+     */
+    public ReportType getReportType() {
+        return reportType;
     }
 }

--- a/src/main/java/io/testproject/sdk/internal/rest/messages/SessionResponse.java
+++ b/src/main/java/io/testproject/sdk/internal/rest/messages/SessionResponse.java
@@ -55,6 +55,11 @@ public class SessionResponse {
     private String version;
 
     /**
+     * Local Report File Path.
+     */
+    private String localReport;
+
+    /**
      * Getter for {@link #devSocketPort} field.
      *
      * @return value of {@link #devSocketPort} field
@@ -106,5 +111,14 @@ public class SessionResponse {
      */
     public String getVersion() {
         return version;
+    }
+
+    /**
+     * Getter for {@link #localReport} field.
+     *
+     * @return value of {@link #localReport} field
+     */
+    public String getLocalReport() {
+        return localReport;
     }
 }

--- a/src/test/java/io/testproject/sdk/tests/examples/drivers/AndroidDriverChromeTest.java
+++ b/src/test/java/io/testproject/sdk/tests/examples/drivers/AndroidDriverChromeTest.java
@@ -66,7 +66,7 @@ class AndroidDriverChromeTest {
         capabilities.setCapability(MobileCapabilityType.UDID, DUT_UDID);
         capabilities.setCapability(CapabilityType.BROWSER_NAME, BrowserType.CHROME);
 
-        driver = new AndroidDriver<>(capabilities, "Examples", null);
+        driver = new AndroidDriver<>(capabilities, "Examples");
     }
 
     @Test

--- a/src/test/java/io/testproject/sdk/tests/examples/drivers/AndroidDriverTest.java
+++ b/src/test/java/io/testproject/sdk/tests/examples/drivers/AndroidDriverTest.java
@@ -79,7 +79,7 @@ class AndroidDriverTest {
         capabilities.setCapability(AndroidMobileCapabilityType.APP_PACKAGE, AUT_PACKAGE_NAME);
         capabilities.setCapability(AndroidMobileCapabilityType.APP_ACTIVITY, AUT_ACTIVITY);
 
-        driver = new AndroidDriver<>(capabilities, "Examples", null);
+        driver = new AndroidDriver<>(capabilities, "Examples");
     }
 
     @Test

--- a/src/test/java/io/testproject/sdk/tests/examples/drivers/ChromeDriverTest.java
+++ b/src/test/java/io/testproject/sdk/tests/examples/drivers/ChromeDriverTest.java
@@ -45,7 +45,7 @@ class ChromeDriverTest {
 
     @BeforeAll
     static void setup() throws InvalidTokenException, AgentConnectException, ObsoleteVersionException, IOException {
-        driver = new ChromeDriver(new ChromeOptions(), "Examples", null);
+        driver = new ChromeDriver(new ChromeOptions(), "Examples");
     }
 
     @Test

--- a/src/test/java/io/testproject/sdk/tests/examples/drivers/EdgeDriverTest.java
+++ b/src/test/java/io/testproject/sdk/tests/examples/drivers/EdgeDriverTest.java
@@ -45,7 +45,7 @@ class EdgeDriverTest {
 
     @BeforeAll
     static void setup() throws InvalidTokenException, AgentConnectException, ObsoleteVersionException, IOException {
-        driver = new EdgeDriver(new EdgeOptions(), "Examples", null);
+        driver = new EdgeDriver(new EdgeOptions(), "Examples");
     }
 
     @Test

--- a/src/test/java/io/testproject/sdk/tests/examples/drivers/FirefoxDriverTest.java
+++ b/src/test/java/io/testproject/sdk/tests/examples/drivers/FirefoxDriverTest.java
@@ -45,7 +45,7 @@ class FirefoxDriverTest {
 
     @BeforeAll
     static void setup() throws InvalidTokenException, AgentConnectException, ObsoleteVersionException, IOException {
-        driver = new FirefoxDriver(new FirefoxOptions(), "Example Project", null);
+        driver = new FirefoxDriver(new FirefoxOptions(), "Example Project");
     }
 
     @Test

--- a/src/test/java/io/testproject/sdk/tests/examples/drivers/GenericDriverTest.java
+++ b/src/test/java/io/testproject/sdk/tests/examples/drivers/GenericDriverTest.java
@@ -43,7 +43,7 @@ class GenericDriverTest {
 
     @BeforeAll
     static void setup() throws InvalidTokenException, AgentConnectException, ObsoleteVersionException, IOException {
-        driver = new GenericDriver("Examples", null);
+        driver = new GenericDriver("Examples");
     }
 
     @Test

--- a/src/test/java/io/testproject/sdk/tests/examples/drivers/IOSDriverTest.java
+++ b/src/test/java/io/testproject/sdk/tests/examples/drivers/IOSDriverTest.java
@@ -82,7 +82,7 @@ class IOSDriverTest {
         // Compile and deploy the App from source https://github.com/testproject-io/ios-demo-app
         capabilities.setCapability(IOSMobileCapabilityType.BUNDLE_ID, AUT_BUNDLE_ID);
 
-        driver = new IOSDriver<>(capabilities, "Examples", null);
+        driver = new IOSDriver<>(capabilities, "Examples");
     }
 
     @Test

--- a/src/test/java/io/testproject/sdk/tests/examples/drivers/IOSSafariDriverTest.java
+++ b/src/test/java/io/testproject/sdk/tests/examples/drivers/IOSSafariDriverTest.java
@@ -72,7 +72,7 @@ class IOSSafariDriverTest {
         capabilities.setCapability(MobileCapabilityType.DEVICE_NAME, DUT_NAME);
         capabilities.setCapability(CapabilityType.BROWSER_NAME, BrowserType.SAFARI);
 
-        driver = new IOSDriver<>(capabilities, "Examples", null);
+        driver = new IOSDriver<>(capabilities, "Examples");
     }
 
     @Test

--- a/src/test/java/io/testproject/sdk/tests/examples/drivers/InternetExplorerDriverTest.java
+++ b/src/test/java/io/testproject/sdk/tests/examples/drivers/InternetExplorerDriverTest.java
@@ -48,7 +48,7 @@ class InternetExplorerDriverTest {
 
     @BeforeAll
     static void setup() throws InvalidTokenException, AgentConnectException, ObsoleteVersionException, IOException {
-        driver = new InternetExplorerDriver(new InternetExplorerOptions(), "Examples", null);
+        driver = new InternetExplorerDriver(new InternetExplorerOptions(), "Examples");
     }
 
     @Test

--- a/src/test/java/io/testproject/sdk/tests/examples/drivers/RemoteWebDriverTest.java
+++ b/src/test/java/io/testproject/sdk/tests/examples/drivers/RemoteWebDriverTest.java
@@ -48,7 +48,7 @@ class RemoteWebDriverTest {
     void testExampleChrome()
             throws MalformedURLException, InvalidTokenException, AgentConnectException, ObsoleteVersionException {
         org.openqa.selenium.WebDriver driver = new RemoteWebDriver(new ChromeOptions(),
-                "Examples", null);
+                "Examples");
         AutomationFlows.runFlow(driver);
         driver.quit();
     }
@@ -58,7 +58,7 @@ class RemoteWebDriverTest {
     void testExampleFirefox()
             throws MalformedURLException, InvalidTokenException, AgentConnectException, ObsoleteVersionException {
         org.openqa.selenium.WebDriver driver = new RemoteWebDriver(new FirefoxOptions(),
-                "Examples", null);
+                "Examples");
         AutomationFlows.runFlow(driver);
         driver.quit();
     }
@@ -69,7 +69,7 @@ class RemoteWebDriverTest {
     void testExampleSafari()
             throws MalformedURLException, InvalidTokenException, AgentConnectException, ObsoleteVersionException {
         org.openqa.selenium.WebDriver driver = new RemoteWebDriver(new SafariOptions(),
-                "Examples", null);
+                "Examples");
         AutomationFlows.runFlow(driver);
         driver.quit();
     }
@@ -80,7 +80,7 @@ class RemoteWebDriverTest {
     void testExampleInternetExplorer()
             throws MalformedURLException, InvalidTokenException, AgentConnectException, ObsoleteVersionException {
         org.openqa.selenium.WebDriver driver = new RemoteWebDriver(new InternetExplorerOptions(),
-                "Examples", null);
+                "Examples");
         AutomationFlows.runFlow(driver);
         driver.quit();
     }
@@ -90,7 +90,7 @@ class RemoteWebDriverTest {
     void testExampleEdge()
             throws MalformedURLException, InvalidTokenException, AgentConnectException, ObsoleteVersionException {
         org.openqa.selenium.WebDriver driver = new RemoteWebDriver(new EdgeOptions(),
-                "Examples", null);
+                "Examples");
         AutomationFlows.runFlow(driver);
         driver.quit();
     }

--- a/src/test/java/io/testproject/sdk/tests/examples/drivers/SafariDriverTest.java
+++ b/src/test/java/io/testproject/sdk/tests/examples/drivers/SafariDriverTest.java
@@ -48,7 +48,7 @@ class SafariDriverTest {
 
     @BeforeAll
     static void setup() throws InvalidTokenException, AgentConnectException, ObsoleteVersionException, IOException {
-        driver = new SafariDriver(new SafariOptions(), "Examples", null);
+        driver = new SafariDriver(new SafariOptions(), "Examples");
     }
 
     @Test


### PR DESCRIPTION
When a **local** report is not supported - SDK will output:

`Target Agent version [2.0.0] doesn't support local reports. Upgrade the Agent to the latest version and try again.`

When local **cloud** is requested but Agent is offline, SDK will output:

`Agent responded with status 412: [Agent is offline and is not able to upload the execution report to the cloud as requested]`