### PR TITLE
Do not report methods without @Test annotation as JUnit tests.

### DIFF
--- a/src/main/java/io/testproject/sdk/internal/reporting/inferrers/JUnitInferrer.java
+++ b/src/main/java/io/testproject/sdk/internal/reporting/inferrers/JUnitInferrer.java
@@ -164,6 +164,15 @@ public class JUnitInferrer implements ReportSettingsInferrer {
                 continue;
             }
 
+            // If not JUnit @Test method, nothing to infer.
+            if (Arrays.stream(method.get().getDeclaredAnnotations())
+                    .noneMatch(a -> Arrays.asList(JUNIT4_TEST_ANNOTATION, JUNIT5_TEST_ANNOTATION)
+                                           .contains(a.annotationType().getName()))) {
+                LOG.trace("No JUnit test annotations detected, skipping inferring {} method name", method.get()
+                        .getName());
+                return null;
+            }
+
             // Search for @DisplayName annotation
             Optional<Annotation> displayNameAnnotation =
                     Arrays.stream(method.get().getDeclaredAnnotations())


### PR DESCRIPTION
Check method being reported when inferring JUnit test name for Test annotation, and return null to avoid
reporting it as a test if it does not have one.

Signed-off-by: David Goichman <david.goichman@testproject.io>