### PR TITLE
Add support for JUnit4 assertion reporting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Examples of explicit Project & Job names configuration:
 
 Reporting extensions extend the TestProject SDK reporting capabilities by intercepting unit testing framework assertions or exceptions thrown, and reporting them as failing steps.
 
-### JUnit
+### JUnit5
 
 In order to integrate it, a relevant interface needs to be implemented by your test class, for example:
 
@@ -282,6 +282,19 @@ ReportingDriver getDriver();
 ```
 
 The method should provide access to the driver that is used for reporting.
+
+### JUnit4
+
+In order to integrate it, your test class will need to use the ExceptionsReportListener from the SDK.
+
+To use it, annoate your test class with the @RunWith annotation and specify the ExceptionsReportListener class.
+
+```java
+import io.testproject.sdk.internal.reporting.extensions.junit4.ExceptionsReportListener;
+
+@RunWith(ExceptionsReportListener.class)
+public class ExceptionsReportTest
+```
 
 ## Tests Reports
 

--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     api group: 'com.google.guava', name: 'guava', version: '29.0-jre'
 
     // JUnit4
-    testImplementation group: 'junit', name: 'junit', version: '4.13'
+    implementation group: 'junit', name: 'junit', version: '4.13'
 
     // JUnit5
     implementation 'org.junit.jupiter:junit-jupiter-api:5.5.1'

--- a/src/main/java/io/testproject/sdk/internal/reporting/extensions/junit4/ExceptionsReportListener.java
+++ b/src/main/java/io/testproject/sdk/internal/reporting/extensions/junit4/ExceptionsReportListener.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2021 TestProject LTD. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.testproject.sdk.internal.reporting.extensions.junit4;
+
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runners.BlockJUnit4ClassRunner;
+import org.junit.runners.model.InitializationError;
+
+/**
+ * JUnit4 Test class runner using the Exceptions reporter.
+ * The test runner class must be specified in a @RunWith annotation
+ * to enable assertion reporting.
+ */
+public class ExceptionsReportListener extends BlockJUnit4ClassRunner {
+
+    /**
+     * Default constructor.
+     * @param testClass
+     * @throws InitializationError
+     */
+    public ExceptionsReportListener(final Class<?> testClass) throws InitializationError {
+        super(testClass);
+    }
+
+    /**
+     * Register test case failure event listener.
+     * @param notifier
+     */
+    @Override
+    public void run(final RunNotifier notifier) {
+        notifier.addListener(new ExceptionsReporter());
+        super.run(notifier);
+    }
+}

--- a/src/main/java/io/testproject/sdk/internal/reporting/extensions/junit4/ExceptionsReporter.java
+++ b/src/main/java/io/testproject/sdk/internal/reporting/extensions/junit4/ExceptionsReporter.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2021 TestProject LTD. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.testproject.sdk.internal.reporting.extensions.junit4;
+
+import io.testproject.sdk.internal.rest.AgentClient;
+import io.testproject.sdk.internal.rest.messages.StepReport;
+import org.junit.runner.notification.Failure;
+import org.junit.runner.notification.RunListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * JUnit4 extension that takes care of reporting failed assertions.
+ */
+public class ExceptionsReporter extends RunListener {
+
+    /**
+     * Logger instance.
+     */
+    private static final Logger LOG = LoggerFactory.getLogger(ExceptionsReporter.class);
+
+    /**
+     * Event listener for test failure.
+     * Will create and report assertion errors.
+     *
+     * @param failure object of the current test.
+     */
+    public void testFailure(final Failure failure) {
+
+        AgentClient reportingClient = AgentClient.getInstance();
+
+        if (reportingClient == null) {
+            LOG.error("No reporting client available, please make sure you have a TestProject driver initialized");
+            return;
+        }
+
+        // Report the error.
+        // Proceed only if error is instance of assertion error.
+        if (!(failure.getException() instanceof AssertionError)) {
+            return;
+        }
+
+        // Get the assertion error message.
+        String resultDescription = failure.getException().getMessage();
+        // Proceed only if message is not empty.
+        if (resultDescription.isEmpty()) {
+            return;
+        }
+
+        // Skip reporting when disabled, just log it.
+        if (reportingClient.getReportsDisabled()) {
+            LOG.trace("Step [{}] - [{}]", resultDescription, false);
+            return;
+        }
+
+        // Finally, submit the report
+        StepReport report = new StepReport(resultDescription, null, false, null);
+        if (!reportingClient.reportStep(report)) {
+            LOG.error("Failed reporting exception: [{}]", report);
+        }
+
+    }
+}

--- a/src/main/java/io/testproject/sdk/internal/reporting/extensions/junit4/package-info.java
+++ b/src/main/java/io/testproject/sdk/internal/reporting/extensions/junit4/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2021 TestProject LTD. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal classes used to operate the SDK.
+ *
+ * @since 1.0.0
+ */
+package io.testproject.sdk.internal.reporting.extensions.junit4;

--- a/src/main/java/io/testproject/sdk/internal/rest/AgentClient.java
+++ b/src/main/java/io/testproject/sdk/internal/rest/AgentClient.java
@@ -195,6 +195,11 @@ public final class AgentClient implements Closeable {
     private boolean skipInferring = false;
 
     /**
+     * Boolean value to determine if reporting was disabled.
+     */
+    private boolean reportsDisabled = false;
+
+    /**
      * Session initialization response.
      */
     private SessionResponse agentResponse;
@@ -247,6 +252,7 @@ public final class AgentClient implements Closeable {
         this.httpClient = httpClientBuilder.build();
 
         // Start Session
+        this.reportsDisabled = disableReports;
         ReportSettings sessionReportSettings = disableReports ? null : inferReportSettings(reportSettings);
 
         try {
@@ -900,6 +906,16 @@ public final class AgentClient implements Closeable {
      */
     public boolean getSkipInferring() {
         return skipInferring;
+    }
+
+    /**
+     * Getter for {@link #reportsDisabled field}.
+     * Used to check if the reports were explicitly disabled.
+     *
+     * @return true if the reports were disabled.
+     */
+    public boolean getReportsDisabled() {
+        return reportsDisabled;
     }
 
     /**

--- a/src/test/java/io/testproject/sdk/tests/examples/frameworks/junit4/ExceptionsReportTest.java
+++ b/src/test/java/io/testproject/sdk/tests/examples/frameworks/junit4/ExceptionsReportTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2021 TestProject LTD. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.testproject.sdk.tests.examples.frameworks.junit4;
+
+import io.testproject.sdk.drivers.web.ChromeDriver;
+import io.testproject.sdk.internal.exceptions.AgentConnectException;
+import io.testproject.sdk.internal.exceptions.InvalidTokenException;
+import io.testproject.sdk.internal.exceptions.ObsoleteVersionException;
+import io.testproject.sdk.internal.reporting.extensions.junit4.ExceptionsReportListener;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.openqa.selenium.chrome.ChromeOptions;
+
+import java.io.IOException;
+
+import static org.junit.Assert.fail;
+
+
+/**
+ * Demonstrates the use of Assertions and Exceptions in a JUnit4 test class.
+ */
+@RunWith(ExceptionsReportListener.class)
+public class ExceptionsReportTest {
+
+
+    /**
+     * Driver instance.
+     */
+    private static ChromeDriver driver;
+
+    /**
+     * Setup method to construct the driver used in the test.
+     *
+     * @throws InvalidTokenException
+     * @throws AgentConnectException
+     * @throws ObsoleteVersionException
+     * @throws IOException
+     */
+    @BeforeClass
+    public static void setup() throws InvalidTokenException, AgentConnectException, ObsoleteVersionException,
+            IOException {
+        driver = new ChromeDriver(new ChromeOptions(), "Examples", "JUnit4 Assertions Example");
+    }
+
+    /**
+     * Use fail() method to fail the test.
+     */
+    @Test
+    public void testExample() {
+        driver.report().step("Simple Step");
+        fail("This test failed");
+    }
+
+    /**
+     * Fail the test using an assertion that will be false.
+     */
+    @Test
+    public void testExample2() {
+        driver.navigate().to("http://example.testproject.io/");
+        String title = driver.getTitle();
+        Assert.assertEquals("another title", title);
+    }
+
+    /**
+     * Throw an assertion error to fail the test.
+     */
+    @Test
+    public void testExample3() {
+        driver.navigate().to("http://example.testproject.io/");
+        String title = driver.getTitle();
+        if (!title.equals("another title")) {
+            throw new AssertionError("This test failed because the title is not expected");
+        }
+    }
+
+    /**
+     * Quit the driver after the session.
+     */
+    @AfterClass
+    public static void tearDown() {
+        if (driver != null) {
+            driver.quit();
+        }
+    }
+}


### PR DESCRIPTION
Must be implemented by extending the RunListener class and overriding it's failure method.
Then the listener must be registered in a runner class.

To enable the actual assertion reporting, the user will need to register the runner with the RunWith annotation in his test class, similar to the CucumberReporter which also works with JUnit4.