### PR TITLE
Feature: add data provider that allows running parameterized tests in uploaded tests

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,9 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added data providers that allow uploading parameterized tests to TestProject platform.
+
 ## [1.0.0] - 2021-04-01
 
-## Added
+### Added
 
 - Added option to configure report type (cloud, local or both).
 - Added Cucumber framework mobile example test.

--- a/README.md
+++ b/README.md
@@ -697,6 +697,114 @@ Save this file under `src/main/java/assembly` as `test-jar-with-dependencies.xml
 </p>
 </details>
 
+## Uploading parameterized tests
+
+TestProject's platform supports running tests with dynamic parameter values. We can do this with OpenSDK tests as well, using the TestProjectParameterizer class.
+
+**NOTE:** tests written in JUnit 4 do not support parameterization.
+
+### Revealing parameter names
+
+If you want your test parameter names to show in TestProject platform, you must build your jar to expose them.
+
+Gradle configuration:
+
+```
+// Place anywhere in the build.gradle file
+compileTestJava.options.compilerArgs.add '-parameters'
+```
+
+Maven configuration:
+
+```
+<!-- If you already have a compiler plugin, just add the compilerArgs tag. -->
+    <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.7.0</version>
+                <configuration>
+                    <source>11</source>
+                    <target>11</target>
+                    <encoding>UTF-8</encoding>
+                    <compilerArgs>
+                        <arg>-parameters</arg>
+                    </compilerArgs>
+                </configuration>
+   </plugin>
+```
+
+### JUnit 5
+
+To let TestProject parameterize JUnit 5, OpenSDK provided a custom *ArgumentsSource* class called `TestProjectParameterizer`.
+Here's a simple example of a parameterized test that is ready for upload:
+
+```java
+import io.testproject.sdk.drivers.web.ChromeDriver;
+import io.testproject.sdk.interfaces.parameterization.TestProjectParameterizer;
+import io.testproject.sdk.internal.exceptions.AgentConnectException;
+import io.testproject.sdk.internal.exceptions.InvalidTokenException;
+import io.testproject.sdk.internal.exceptions.ObsoleteVersionException;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.openqa.selenium.By;
+import org.openqa.selenium.chrome.ChromeOptions;
+
+import java.io.IOException;
+public class JUnit5Example {
+    @ParameterizedTest
+    @ArgumentsSource(TestProjectParameterizer.class)
+    public void paramTest(String username, String password)
+            throws InvalidTokenException, AgentConnectException, ObsoleteVersionException, IOException {
+        ChromeDriver driver = new ChromeDriver(new ChromeOptions());
+
+        // Navigate to TestProject Example website
+        driver.navigate().to("https://example.testproject.io/web/");
+
+        // Login using provided credentials
+        driver.findElement(By.cssSelector("#name")).sendKeys(username);
+        driver.findElement(By.cssSelector("#password")).sendKeys(password);
+        driver.findElement(By.cssSelector("#login")).click();
+        driver.quit();
+    }
+}
+```
+
+### TestNG
+
+To let TestProject parameterize JUnit 5, OpenSDK provided a custom *dataProvider* inside the `TestProjectParameterizer` class called "TestProject".
+Here's a simple example of a parameterized test that is ready for upload:
+
+```java
+import io.testproject.sdk.drivers.web.ChromeDriver;
+import io.testproject.sdk.interfaces.parameterization.TestProjectParameterizer;
+import io.testproject.sdk.internal.exceptions.AgentConnectException;
+import io.testproject.sdk.internal.exceptions.InvalidTokenException;
+import io.testproject.sdk.internal.exceptions.ObsoleteVersionException;
+import org.openqa.selenium.By;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+public class TestNGExample {
+    @Test(dataProvider = "TestProject", dataProviderClass = TestProjectParameterizer.class)
+    public void paramTest(final String username, final String password)
+            throws InvalidTokenException, AgentConnectException, ObsoleteVersionException, IOException {
+        ChromeDriver driver = new ChromeDriver(new ChromeOptions());
+
+        // Navigate to TestProject Example website
+        driver.navigate().to("https://example.testproject.io/web/");
+
+        // Login using provided credentials
+        driver.findElement(By.cssSelector("#name")).sendKeys(username);
+        driver.findElement(By.cssSelector("#password")).sendKeys(password);
+        driver.findElement(By.cssSelector("#login")).click();
+
+        driver.quit();
+    }
+}
+```
+
 # Examples
 
 Here are more [examples](/src/test/java/io/testproject/sdk/tests/examples):

--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,8 @@ dependencies {
     // JUnit5
     implementation 'org.junit.jupiter:junit-jupiter-api:5.5.1'
 
+    implementation 'org.junit.jupiter:junit-jupiter-params:5.5.1'
+
     // Module "junit-jupiter-params" of JUnit 5.
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: '5.5.1'
 
@@ -86,6 +88,8 @@ dependencies {
     // Maven Artifact
     implementation 'org.apache.maven:maven-artifact:3.6.3'
 
+    // Apache commons
+    implementation group: 'org.apache.commons', name: 'commons-csv', version: '1.8'
 }
 
 checkstyle.configFile file("config/checkstyle/checkstyle.xml")

--- a/src/main/java/io/testproject/sdk/interfaces/parameterization/TestProjectParameterizer.java
+++ b/src/main/java/io/testproject/sdk/interfaces/parameterization/TestProjectParameterizer.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2021 TestProject LTD. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.testproject.sdk.interfaces.parameterization;
+
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.testng.annotations.DataProvider;
+
+import java.io.File;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * This class is used to provide arguments from TestProject platform to parameterized tests.
+ */
+public class TestProjectParameterizer implements ArgumentsProvider {
+    /**
+     * Environment variable for data provider contents.
+     */
+    private static final String DATA_PROVIDER_ENV = "TP_TEST_DATA_PROVIDER";
+
+    /**
+     * Provides arguments for TestNG tests.
+     * @return Test arguments.
+     * @throws Exception If unable to read arguments
+     */
+    @DataProvider(name = "TestProject")
+    public static Object[][] provideArguments() throws Exception {
+        List<String[]> strings = getCSVLines();
+        return strings.toArray(new Object[0][]);
+    }
+
+    /**
+     * Provides arguments for JUnit 5 tests.
+     * @param context Extension context.
+     * @return Test arguments.
+     * @throws Exception If unable to read arguments
+     */
+    @Override
+    public Stream<? extends Arguments> provideArguments(final ExtensionContext context) throws Exception {
+        List<String[]> strings = getCSVLines();
+        return strings.stream().map(Arguments::of);
+    }
+
+    private static List<String[]> getCSVLines() throws Exception {
+        String dataProviderPath = System.getenv(DATA_PROVIDER_ENV);
+        if (StringUtils.isEmpty(dataProviderPath)) {
+            throw new IllegalArgumentException("No data provider was specified. "
+                    + "Make sure this annotation is used for uploaded tests only.");
+        }
+        File dataProviderFile = new File(dataProviderPath);
+        if (!dataProviderFile.exists()) {
+            throw new IllegalArgumentException("No data provider was specified. "
+                    + "Make sure this annotation is used for uploaded tests only.");
+        }
+
+        // Read CSV & collect the contents
+        CSVParser parser = CSVParser.parse(dataProviderFile, Charset.defaultCharset(), CSVFormat.DEFAULT);
+        return parser.getRecords().stream().skip(1).map(record -> {
+            Iterator<String> iterator = record.iterator();
+            List<String> recordValues = new ArrayList<>();
+            iterator.forEachRemaining(recordValues::add);
+            return recordValues.toArray(new String[0]);
+        }).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/io/testproject/sdk/interfaces/parameterization/package-info.java
+++ b/src/main/java/io/testproject/sdk/interfaces/parameterization/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2021 TestProject LTD. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Provides custom parameterization for uploaded tests.
+ */
+package io.testproject.sdk.interfaces.parameterization;

--- a/src/test/java/io/testproject/sdk/tests/examples/parameterization/JUnitTests.java
+++ b/src/test/java/io/testproject/sdk/tests/examples/parameterization/JUnitTests.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2021 TestProject LTD. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.testproject.sdk.tests.examples.parameterization;
+
+import io.testproject.sdk.drivers.web.ChromeDriver;
+import io.testproject.sdk.interfaces.parameterization.TestProjectParameterizer;
+import io.testproject.sdk.internal.exceptions.AgentConnectException;
+import io.testproject.sdk.internal.exceptions.InvalidTokenException;
+import io.testproject.sdk.internal.exceptions.ObsoleteVersionException;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.openqa.selenium.By;
+import org.openqa.selenium.chrome.ChromeOptions;
+
+import java.io.IOException;
+
+@EnabledIfEnvironmentVariable(named = "TP_DEV_TOKEN", matches = ".*?")
+public final class JUnitTests {
+    /**
+     * A simple parameterized test.
+     * @param username The username.
+     * @param password The password
+     * @throws InvalidTokenException If token is invalid.
+     * @throws AgentConnectException If unable to connect to agent.
+     * @throws ObsoleteVersionException If SDK version is obsolete.
+     * @throws IOException On any IO error.
+     */
+    @ParameterizedTest
+    @ArgumentsSource(TestProjectParameterizer.class)
+    @EnabledIfEnvironmentVariable(named = "TP_TEST_DATA_PROVIDER", matches = ".*?")
+    public void paramTest(final String username, final String password)
+            throws InvalidTokenException, AgentConnectException, ObsoleteVersionException, IOException {
+        ChromeDriver driver = new ChromeDriver(new ChromeOptions());
+
+        // Navigate to TestProject Example website
+        driver.navigate().to("https://example.testproject.io/web/");
+
+        // Login using provided credentials
+        driver.findElement(By.cssSelector("#name")).sendKeys(username);
+        driver.findElement(By.cssSelector("#password")).sendKeys(password);
+        driver.findElement(By.cssSelector("#login")).click();
+
+        boolean passed = driver.findElement(By.cssSelector("#logout")).isDisplayed();
+        if (passed) {
+            System.out.println("Test Passed");
+        } else {
+            System.out.println("Test Failed");
+        }
+
+        driver.quit();
+    }
+}

--- a/src/test/java/io/testproject/sdk/tests/examples/parameterization/TestNGTests.java
+++ b/src/test/java/io/testproject/sdk/tests/examples/parameterization/TestNGTests.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2021 TestProject LTD. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.testproject.sdk.tests.examples.parameterization;
+
+import io.testproject.sdk.drivers.web.ChromeDriver;
+import io.testproject.sdk.interfaces.parameterization.TestProjectParameterizer;
+import io.testproject.sdk.internal.exceptions.AgentConnectException;
+import io.testproject.sdk.internal.exceptions.InvalidTokenException;
+import io.testproject.sdk.internal.exceptions.ObsoleteVersionException;
+import org.openqa.selenium.By;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+public class TestNGTests {
+    /**
+     * A simple parameterized test.
+     * @param username The username.
+     * @param password The password
+     * @throws InvalidTokenException If token is invalid.
+     * @throws AgentConnectException If unable to connect to agent.
+     * @throws ObsoleteVersionException If SDK version is obsolete.
+     * @throws IOException On any IO error.
+     */
+    @Test(dataProvider = "TestProject", dataProviderClass = TestProjectParameterizer.class)
+    public void paramTest(final String username, final String password)
+            throws InvalidTokenException, AgentConnectException, ObsoleteVersionException, IOException {
+        ChromeDriver driver = new ChromeDriver(new ChromeOptions());
+
+        // Navigate to TestProject Example website
+        driver.navigate().to("https://example.testproject.io/web/");
+
+        // Login using provided credentials
+        driver.findElement(By.cssSelector("#name")).sendKeys(username);
+        driver.findElement(By.cssSelector("#password")).sendKeys(password);
+        driver.findElement(By.cssSelector("#login")).click();
+
+        boolean passed = driver.findElement(By.cssSelector("#logout")).isDisplayed();
+        if (passed) {
+            System.out.println("Test Passed");
+        } else {
+            System.out.println("Test Failed");
+        }
+
+        driver.quit();
+    }
+}

--- a/src/test/java/io/testproject/sdk/tests/examples/parameterization/package-info.java
+++ b/src/test/java/io/testproject/sdk/tests/examples/parameterization/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2021 TestProject LTD. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Examples for parameterized tests.
+ */
+package io.testproject.sdk.tests.examples.parameterization;


### PR DESCRIPTION
In order to allow parameterized tests when uploading OpenSDK tests to TestProject platform, we need a custom argument provider that can dynamically specify test parameters. The provider will work as follows:

- Search for the TP_TEST_DATA_PROVIDER environment variable, and fail if it isn't set.
- Check the variable points to an existing file. and fail if it doesn't.
- Read the file contents and return its cells as sets of arguments.

This MR contains both providers for JUnit 5 and TestNG, as well as examples on how to use them.