### PR TITLE
Disable manual command reports when using Cucumber Plugin

### DIFF
--- a/src/main/java/io/testproject/sdk/internal/reporting/Reporter.java
+++ b/src/main/java/io/testproject/sdk/internal/reporting/Reporter.java
@@ -174,7 +174,13 @@ public final class Reporter {
                      final String message,
                      final boolean passed,
                      final boolean screenshot) {
-        // Report Test if needed
+        // Report test step if needed.
+
+        // If manual reporting is disabled, skip.
+        if (Boolean.getBoolean("TP_DISABLE_MANUAL_REPORTS")) {
+            return;
+        }
+
         if (!this.driver.getReportingCommandExecutor().isReportsDisabled()) {
             List<StackTraceElement> traces = Arrays.asList(Thread.currentThread().getStackTrace());
             this.driver.getReportingCommandExecutor().reportTest(traces, false);

--- a/src/main/java/io/testproject/sdk/internal/reporting/extensions/cucumber/CucumberReporter.java
+++ b/src/main/java/io/testproject/sdk/internal/reporting/extensions/cucumber/CucumberReporter.java
@@ -54,6 +54,8 @@ public class CucumberReporter implements EventListener {
         System.setProperty("TP_DISABLE_AUTO_REPORTS", "true");
         // Force session reuse for Cucumber tests.
         System.setProperty("TP_FORCE_SESSION_REUSE", "true");
+        // Disable manual driver reporting.
+        System.setProperty("TP_DISABLE_MANUAL_REPORTS", "true");
     }
 
     /**


### PR DESCRIPTION
To avoid out of order command reports and to match the other SDK's, disable manual command reporting
when using the Cucumber plugin.

Signed-off-by: David Goichman <david.goichman@testproject.io>