### PR TITLE
Avoid ignoring report type in ChromeDriver

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added data providers that allow uploading parameterized tests to TestProject platform.
+- ([#104](https://github.com/testproject-io/java-opensdk/issues/104)) - Fix for Report Type being ignored on Chrome Driver.
+
 
 ## [1.0.0] - 2021-04-01
 

--- a/src/main/java/io/testproject/sdk/drivers/web/ChromeDriver.java
+++ b/src/main/java/io/testproject/sdk/drivers/web/ChromeDriver.java
@@ -93,7 +93,7 @@ public class ChromeDriver extends org.openqa.selenium.chrome.ChromeDriver implem
     public ChromeDriver(final ReportType reportType)
             throws InvalidTokenException, AgentConnectException, IOException,
             ObsoleteVersionException {
-        this(null, null, new ChromeOptions());
+        this(null, null, new ChromeOptions(), reportType);
     }
 
     /**


### PR DESCRIPTION
Chrome Driver no longer ignores Report Type if it is the only parameter in the driver constructor,

Signed-off-by: Ran Tzur <ran.tzur@testproject.io>