### PR TITLE
 infer missing report settings when re-creating AgentClient instance.

### DIFF
--- a/src/main/java/io/testproject/sdk/internal/rest/AgentClient.java
+++ b/src/main/java/io/testproject/sdk/internal/rest/AgentClient.java
@@ -768,7 +768,7 @@ public final class AgentClient implements Closeable {
      * @param reportSettings Project and Job names provided explicitly.
      * @return {@link ReportSettings} instance with discovered Project and Job names.
      */
-    private ReportSettings inferReportSettings(final ReportSettings reportSettings) {
+    private static ReportSettings inferReportSettings(final ReportSettings reportSettings) {
 
         if (reportSettings != null
                 && !StringUtils.isEmpty(reportSettings.getProjectName())
@@ -814,7 +814,7 @@ public final class AgentClient implements Closeable {
                 result.getProjectName(), result.getJobName());
 
         if (Boolean.getBoolean("TP_DISABLE_AUTO_REPORTS")) {
-            skipInferring = true;
+            instance.skipInferring = true;
         }
 
         return result;

--- a/src/main/java/io/testproject/sdk/internal/rest/AgentClient.java
+++ b/src/main/java/io/testproject/sdk/internal/rest/AgentClient.java
@@ -509,10 +509,16 @@ public final class AgentClient implements Closeable {
                     capabilities.getCapability(TP_GUID))) {
 
                 // Close existing session if required
+                ReportSettings settings = reportSettings;
                 if (instance != null) {
-                    boolean sameReportSettings = instance.getReportSetting() != null
-                            && instance.getReportSetting().equals(reportSettings);
+                    // If either setting is null we need to re-infer settings.
+                    // Without it we can't reuse previously-inferred settings.
+                    if (settings.getProjectName() == null || settings.getJobName() == null) {
+                        settings = inferReportSettings(reportSettings);
+                    }
 
+                    boolean sameReportSettings = instance.getReportSetting() != null
+                            && instance.getReportSetting().equals(settings);
                     // If the report doesn't go to the same Project/Job,
                     // or Agent doesn't support session reuse - close it.
                     // and Cucumber does not force session reuse.
@@ -526,7 +532,7 @@ public final class AgentClient implements Closeable {
                 }
 
                 // No instance yet or it's for another driver and needs to be re-initialized
-                instance = new AgentClient(remoteAddress, token, capabilities, reportSettings, disableReports);
+                instance = new AgentClient(remoteAddress, token, capabilities, settings, disableReports);
             }
         }
 


### PR DESCRIPTION
When AgentClient instance is re-created, we compare the settings to check if we need to reopen the session.
If the report settings are inferred from test class, then the report setting will never match because the values are currently null.
We should infer the settings on creation before comparing the settings

Issue: https://github.com/testproject-io/java-opensdk/issues/110