### PR TITLE
Added warning log when manual reporting is attempted while disabled.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added warning log for when trying to use manual reporting while it is disabled.
+
 ## [1.2.0] - 2021-05-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -590,6 +590,8 @@ Instead, it will report:
 To use the plugin you must have an active TestProject driver instance before the execution of the features
 begins, either initializing the driver as the first step in your test or in a @BeforeClass annotated method.
 
+Please note that while using the CucumberReporter, manual test reporting will be disabled.
+
 If you are running your features via a JUnit Cucumber runner, you will need to specify the plugin from 
 the @CucumberOptions annotation as seen below:
 

--- a/src/main/java/io/testproject/sdk/internal/reporting/Reporter.java
+++ b/src/main/java/io/testproject/sdk/internal/reporting/Reporter.java
@@ -224,6 +224,7 @@ public final class Reporter {
 
         // If manual reporting is disabled, skip.
         if (Boolean.getBoolean("TP_DISABLE_MANUAL_REPORTS")) {
+            LOG.warn("Manual reporting is disabled");
             return;
         }
 


### PR DESCRIPTION
As well as updated documentation for the Cucumber reporter, being the instance where manual reporting is disabled.