### PR TITLE
Increase maximum reporting time and log reporting progress,

### DIFF
--- a/src/main/java/io/testproject/sdk/internal/rest/AgentClient.java
+++ b/src/main/java/io/testproject/sdk/internal/rest/AgentClient.java
@@ -65,7 +65,7 @@ public final class AgentClient implements Closeable {
     /**
      * Maximum amount of time to wait in seconds before forcibly terminating the queue.
      */
-    public static final int REPORTS_QUEUE_TIMEOUT = 10;
+    public static final int REPORTS_QUEUE_TIMEOUT = 60 * 10;
 
     /**
      * Constant for a custom capability name used to track AgentClient instances.


### PR DESCRIPTION
- Increased the maximum time for the queue to 10 minutes.
- Gave each queue item a unique index, logged it after it was reported along with the amount of reports remaining in the queue.