### PR TITLE
Add new ReportsQueue to support reporting at batches.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,6 +90,9 @@ dependencies {
 
     // Apache commons
     implementation group: 'org.apache.commons', name: 'commons-csv', version: '1.8'
+
+    // Java API for RESTful Web Services
+    implementation 'javax.ws.rs:javax.ws.rs-api:2.1.1'
 }
 
 checkstyle.configFile file("config/checkstyle/checkstyle.xml")

--- a/src/main/java/io/testproject/sdk/internal/exceptions/FailedReportException.java
+++ b/src/main/java/io/testproject/sdk/internal/exceptions/FailedReportException.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2020 TestProject LTD. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.testproject.sdk.internal.exceptions;
+
+/**
+ * This exception is thrown when SDK fails to send a report to the agent.
+ */
+public class FailedReportException extends Exception {
+    /**
+     * Default serial version ID.
+     */
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Creates a new instance of the class with a default message.
+     */
+    public FailedReportException() {
+        this("Failed sending a report to the Agent");
+    }
+
+    /**
+     * Creates a new instance of the class with a provided message.
+     *
+     * @param message message to be set
+     */
+    public FailedReportException(final String message) {
+        super(message);
+    }
+
+    /**
+     * Creates a new instance of the class with a provided message and cause.
+     *
+     * @param message message to be set
+     * @param cause   another exception that caused this one
+     */
+    public FailedReportException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/io/testproject/sdk/internal/rest/AgentClient.java
+++ b/src/main/java/io/testproject/sdk/internal/rest/AgentClient.java
@@ -1236,7 +1236,7 @@ public final class AgentClient implements Closeable {
     /**
      * Internal class used to store Agent API routes.
      */
-    private static class Routes {
+    static class Routes {
         /**
          * Agent "status" endpoint address.
          */
@@ -1261,6 +1261,11 @@ public final class AgentClient implements Closeable {
          * Test reporting endpoint address.
          */
         static final String REPORT_TEST = "/api/development/report/test";
+
+        /**
+         * Batch reporting endpoint address.
+         */
+        static final String REPORT_BATCH = "/api/development/report/batch";
 
         /**
          * Action proxy execution endpoint address.

--- a/src/main/java/io/testproject/sdk/internal/rest/AgentClient.java
+++ b/src/main/java/io/testproject/sdk/internal/rest/AgentClient.java
@@ -211,6 +211,12 @@ public final class AgentClient implements Closeable {
     private SessionResponse agentResponse;
 
     /**
+     * Minimum Agent version that supports batch reporting.
+     */
+    private static final String MIN_BATCH_REPORT_SUPPORTED_VERSION = "3.1.0";
+
+
+    /**
      * Creates a new instance of the class.
      * Initiates a development session with the Agent.
      *
@@ -290,7 +296,13 @@ public final class AgentClient implements Closeable {
 
         // Start reports queue
         if (!disableReports) {
-            this.reportsQueue = new ReportsQueue(this.httpClient, this.getSession().getSessionId());
+            if (new ComparableVersion(version).compareTo(
+                    new ComparableVersion(MIN_BATCH_REPORT_SUPPORTED_VERSION)) >= 0) {
+                        this.reportsQueue = new ReportsQueueBatch(
+                                this.httpClient, this.getSession().getSessionId(), this.remoteAddress);
+            } else {
+                this.reportsQueue = new ReportsQueue(this.httpClient, this.getSession().getSessionId());
+            }
             this.reportsQueueFuture = reportsExecutorService.submit(this.reportsQueue);
         }
 

--- a/src/main/java/io/testproject/sdk/internal/rest/ReportsQueue.java
+++ b/src/main/java/io/testproject/sdk/internal/rest/ReportsQueue.java
@@ -19,23 +19,24 @@ package io.testproject.sdk.internal.rest;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import io.testproject.sdk.internal.exceptions.FailedReportException;
 import io.testproject.sdk.internal.rest.messages.Report;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
+import org.apache.http.client.methods.HttpPost;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.util.EntityUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.ws.rs.core.Response;
 import java.io.IOException;
-import java.net.HttpURLConnection;
 import java.util.concurrent.*;
 
 /**
  * A runnable class to manage reports queue.
  */
 public class ReportsQueue implements Runnable {
-
     /**
      * Logger instance.
      */
@@ -44,10 +45,22 @@ public class ReportsQueue implements Runnable {
     /**
      * An instance of the Google JSON serializer to serialize and deserialize objects.
      */
-    private static final Gson GSON = new GsonBuilder().create();
+    protected static final Gson GSON = new GsonBuilder().create();
+
+    /**
+     * Progress report delay in seconds.
+     * Print the number of the remaining reports to send every 3 seconds.
+     */
+    private static final int PROGRESS_REPORT_DELAY = 3;
+
+    /**
+     * Maximum attempts to try sending a report to the Agent.
+     */
+    protected static final int MAX_REPORT_FAILURE_ATTEMPTS = 4;
 
     /**
      * Queue to synchronize reports sent to Agent.
+     * Queue depth defined as 10K - assuming that even with very high latency, the queue won't get full.
      */
     private final LinkedBlockingQueue<QueueItem> queue = new LinkedBlockingQueue<>(1024 * 10);
 
@@ -72,9 +85,9 @@ public class ReportsQueue implements Runnable {
     private Future<?> progressFuture;
 
     /**
-     * Progress report delay in seconds.
+     * A flag that is raised when all attempts submitting a report fail.
      */
-    private static final int PROGRESS_REPORT_DELAY = 3;
+    private boolean stopReports = false;
 
     /**
      * Initializes a new instance of the class.
@@ -94,7 +107,30 @@ public class ReportsQueue implements Runnable {
      * @param report  Report that this request contains.
      */
     void submit(final HttpEntityEnclosingRequestBase request, final Report report) {
-        this.queue.add(new QueueItem(request, report));
+        if (!this.stopReports) {
+            this.queue.add(new QueueItem(request, report));
+        }
+    }
+
+    /**
+     * For lower versions than 3.1.0 -> Send standalone reports.
+     * @throws InterruptedException in case reports queue was interrupted
+     * @throws FailedReportException in case of 4 failures to send reports to the agent
+     */
+    void handleReport() throws InterruptedException, FailedReportException {
+        QueueItem item = this.queue.take();
+
+        if (item.getRequest() == null && item.getReport() == null) {
+            if (this.running) {
+                // There nulls are not OK, something went wrong preparing the report/request.
+                LOG.error("Empty report and request were submitted to the queue!");
+            }
+
+            // These nulls are OK - they were added by stop() method on purpose.
+            return;
+        }
+
+        sendReport((HttpPost) item.getRequest());
     }
 
     /**
@@ -103,13 +139,15 @@ public class ReportsQueue implements Runnable {
     @Override
     public void run() {
         this.running = true;
-
-        while (this.running || queue.size() > 0) {
+        while (this.running || !this.queue.isEmpty()) {
             try {
-                sendReport(queue.take());
+                handleReport();
             } catch (InterruptedException e) {
                 LOG.error("Reports queue was interrupted");
                 break;
+            } catch (FailedReportException e) {
+                this.stopReports = true;
+                LOG.warn("Reports are disabled due to multiple failed attempts of sending reports to the agent.");
             }
         }
 
@@ -122,38 +160,47 @@ public class ReportsQueue implements Runnable {
 
     /**
      * Submits a report to the Agent via HTTP RESTFul API endpoint.
-     *
-     * @param item Item retrieved from the queue (report & HTTP request).
+     * @param httpPost For lower versions than 3.1.0 -> HTTP request retrieved from the queue.
+     *                 For versions 3.1.0 and greater -> Build reports batch HTTP request.
+     * @throws FailedReportException in case of 4 failures to send reports to the agent
      */
-    private void sendReport(final QueueItem item) {
-        if (item.getRequest() == null && item.getReport() == null) {
-            if (this.running) {
-                // There nulls are not OK, something went wrong preparing the report/request.
-                LOG.error("Empty report and request were submitted to the queue!");
-            }
-
-            // These nulls are OK - they were added by stop() method on purpose.
-            return;
-        }
-
+    void sendReport(final HttpPost httpPost) throws FailedReportException {
+        int reportAttemptsCount;
         CloseableHttpResponse response = null;
-        try {
-            response = this.httpClient.execute(item.getRequest());
-        } catch (IOException e) {
-            LOG.error("Failed to submit report: [{}]", item.getReport(), e);
-            return;
-        } finally {
-            // Consume response to release the resources
+        // Send the report to the agent.
+        // In case of failure - make 3 more attempts.
+        for (reportAttemptsCount = MAX_REPORT_FAILURE_ATTEMPTS; reportAttemptsCount > 0; reportAttemptsCount--) {
+            try {
+                response = this.getHttpClient().execute(httpPost);
+            } catch (IOException e) {
+                LOG.error("Failed to submit report.", e);
+            } finally {
+                // Consume response to release the resources
+                if (response != null) {
+                    EntityUtils.consumeQuietly(response.getEntity());
+                }
+            }
+
             if (response != null) {
-                EntityUtils.consumeQuietly(response.getEntity());
+                // If the reports were sent successfully, there is no need to continue to the rest of the code
+                // since it's handling unsuccessful response.
+                if (Response.Status.Family.familyOf(response.getStatusLine().getStatusCode())
+                    == Response.Status.Family.SUCCESSFUL) {
+                    return;
+                }
+
+                // Handle unsuccessful response
+                LOG.warn("Agent responded with an unexpected status {} to report.",
+                        response.getStatusLine().getStatusCode());
+                LOG.info("Failed to send a report to the Agent, {} attempts remaining...", reportAttemptsCount - 1);
             }
         }
 
-        // Handle unsuccessful response
-        if (response != null && response.getStatusLine().getStatusCode() != HttpURLConnection.HTTP_OK) {
-            LOG.error("Agent responded with an unexpected status {} to report: [{}]",
-                    response.getStatusLine().getStatusCode(), item.getReport());
-        }
+        // In case all attempts to send the report are failed.
+        // If the report has been sent successfully - this code will not execute.
+        LOG.error("All {} attempts to send report have failed.", MAX_REPORT_FAILURE_ATTEMPTS);
+        throw new FailedReportException("All " + MAX_REPORT_FAILURE_ATTEMPTS
+                + " attempts to send report have failed.");
     }
 
     /**

--- a/src/main/java/io/testproject/sdk/internal/rest/ReportsQueue.java
+++ b/src/main/java/io/testproject/sdk/internal/rest/ReportsQueue.java
@@ -101,6 +101,22 @@ public class ReportsQueue implements Runnable {
     }
 
     /**
+     * Getter method for {@link #queue}.
+     * @return the reports queue.
+     */
+    protected LinkedBlockingQueue<QueueItem> getQueue() {
+        return queue;
+    }
+
+    /**
+     * Getter method for {@link #httpClient}.
+     * @return the httpClient.
+     */
+    protected CloseableHttpClient getHttpClient() {
+        return httpClient;
+    }
+
+    /**
      * Adds a report to the queue.
      *
      * @param request Request to be sent over HTTP.

--- a/src/main/java/io/testproject/sdk/internal/rest/ReportsQueue.java
+++ b/src/main/java/io/testproject/sdk/internal/rest/ReportsQueue.java
@@ -49,7 +49,7 @@ public class ReportsQueue implements Runnable {
     /**
      * Queue to synchronize reports sent to Agent.
      */
-    private final ArrayBlockingQueue<QueueItem> queue = new ArrayBlockingQueue<>(1024 * 1024);
+    private final LinkedBlockingQueue<QueueItem> queue = new LinkedBlockingQueue<>(1024 * 10);
 
     /**
      * HTTP client to submit reports to the Agent.

--- a/src/main/java/io/testproject/sdk/internal/rest/ReportsQueue.java
+++ b/src/main/java/io/testproject/sdk/internal/rest/ReportsQueue.java
@@ -188,7 +188,7 @@ public class ReportsQueue implements Runnable {
     /**
      * Internal class to keep the HTTP request and contained report together in the queue.
      */
-    private static class QueueItem {
+    static class QueueItem {
 
         /**
          * HTTP request.

--- a/src/main/java/io/testproject/sdk/internal/rest/ReportsQueueBatch.java
+++ b/src/main/java/io/testproject/sdk/internal/rest/ReportsQueueBatch.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2020 TestProject LTD. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.testproject.sdk.internal.rest;
+
+import io.testproject.sdk.internal.exceptions.FailedReportException;
+import io.testproject.sdk.internal.rest.messages.Report;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedList;
+import java.util.List;
+
+public class ReportsQueueBatch extends ReportsQueue {
+    /**
+     * Logger instance.
+     */
+    private static final Logger LOG = LoggerFactory.getLogger(ReportsQueueBatch.class);
+
+    /**
+     * remote url to send the reports to.
+     */
+    private final URL remoteAddress;
+
+    /**
+     * The default batch report size is a maximum of 10 reports.
+     */
+    private static final int MAX_REPORTS_BATCH_SIZE = 10;
+
+    /**
+     * Constant for environment variable name that may store the max batch size.
+     */
+    private static final String TP_MAX_BATCH_SIZE_VARIABLE_NAME = "TP_MAX_REPORTS_BATCH_SIZE";
+
+    /**
+     * Class member to store actual max batch size.
+     */
+    private final int maxBatchSize;
+
+    /**
+     * Initializes a new instance of the class.
+     *
+     * @param httpClient HTTP client ot use for communicating with the Agent.
+     * @param sessionId  Driver session ID.
+     * @param remoteAddress Reports remote address.
+     */
+    ReportsQueueBatch(final CloseableHttpClient httpClient, final String sessionId, final URL remoteAddress) {
+        super(httpClient, sessionId);
+        this.remoteAddress = remoteAddress;
+
+        // Try to get maximum report batch size from env variable.
+        int maxBatchSizeValueToSet;
+        try {
+            String tpMaxBatchSizeEnvVarValue = System.getenv(TP_MAX_BATCH_SIZE_VARIABLE_NAME);
+            maxBatchSizeValueToSet = (tpMaxBatchSizeEnvVarValue != null)
+                    ? Integer.parseInt(tpMaxBatchSizeEnvVarValue) : MAX_REPORTS_BATCH_SIZE;
+        } catch (SecurityException e) {
+            LOG.warn("Failed to retrieve the value of environment variable {}. "
+                            + "Maximum reports batch size is set to the default value: {}.",
+                    TP_MAX_BATCH_SIZE_VARIABLE_NAME, MAX_REPORTS_BATCH_SIZE, e);
+            maxBatchSizeValueToSet = MAX_REPORTS_BATCH_SIZE;
+        } catch (Exception e) {
+            LOG.warn("Failed to convert the value of environment variable {}. "
+                            + "Maximum reports batch size is set to the default value: {}.",
+                    TP_MAX_BATCH_SIZE_VARIABLE_NAME, MAX_REPORTS_BATCH_SIZE, e);
+            maxBatchSizeValueToSet = MAX_REPORTS_BATCH_SIZE;
+        }
+        this.maxBatchSize = maxBatchSizeValueToSet;
+    }
+
+    /**
+     * From version 3.1.0 -> send reports in batches.
+     * Collect reports from reports queue and build reports batch.
+     * Send the reports batch to the agent.
+     * @throws InterruptedException in case reports queue was interrupted
+     * @throws FailedReportException in case of 4 failures to send reports to the agent
+     */
+    @Override
+    void handleReport() throws InterruptedException, FailedReportException {
+        // Linked list to store the reports batch before sending them.
+        // Those reports will be extract from the queue.
+        List<Report> batchReports = new LinkedList<>();
+
+        // Extract and remove up to {this.maxBatchSize} items or till queue is empty from queue - without blocking it.
+        while (!getQueue().isEmpty() && batchReports.size() < this.maxBatchSize) {
+            // Get the first item in the queue without blocking it.
+            QueueItem item = getQueue().poll();
+
+            if (null != item && item.getReport() != null) {
+                batchReports.add(item.getReport());
+            }
+        }
+
+        if (batchReports.isEmpty()) {
+            return;
+        }
+
+        // Create json from reports list
+        String json = null;
+        try {
+            json = this.GSON.toJson(batchReports);
+        } catch (Exception e) {
+            LOG.error("Failed to create json from list: [{}]", batchReports, e);
+            return;
+        }
+
+        // Parse batch report to json string
+        StringEntity entity = new StringEntity(json, StandardCharsets.UTF_8);
+
+        // Create httpPost and execute
+        HttpPost httpPost = new HttpPost(this.remoteAddress + AgentClient.Routes.REPORT_BATCH);
+        httpPost.setEntity(entity);
+
+        this.sendReport(httpPost);
+    }
+}

--- a/src/main/java/io/testproject/sdk/internal/rest/messages/DriverCommandReport.java
+++ b/src/main/java/io/testproject/sdk/internal/rest/messages/DriverCommandReport.java
@@ -49,6 +49,11 @@ public final class DriverCommandReport extends Report {
     private String screenshot;
 
     /**
+     * Define type as Command for batch report support.
+     */
+    private final ReportItemType type = ReportItemType.Command;
+
+    /**
      * Getter for {@link #screenshot} field.
      *
      * @return value of {@link #screenshot} field
@@ -125,4 +130,5 @@ public final class DriverCommandReport extends Report {
     public String toString() {
         return this.commandName;
     }
+
 }

--- a/src/main/java/io/testproject/sdk/internal/rest/messages/ReportItemType.java
+++ b/src/main/java/io/testproject/sdk/internal/rest/messages/ReportItemType.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2020 TestProject LTD. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.testproject.sdk.internal.rest.messages;
+
+public enum ReportItemType {
+    /**
+     * Those are the reports types which are supported to be sent at batches.
+     */
+    Command, Test, Step
+}

--- a/src/main/java/io/testproject/sdk/internal/rest/messages/StepReport.java
+++ b/src/main/java/io/testproject/sdk/internal/rest/messages/StepReport.java
@@ -17,6 +17,7 @@
 
 package io.testproject.sdk.internal.rest.messages;
 
+
 import java.util.UUID;
 
 /**
@@ -48,6 +49,12 @@ public final class StepReport extends Report {
      * Flag to indicate pass/fail state.
      */
     private final boolean passed;
+
+    /**
+     * Define type as Step for batch report support.
+     */
+    private final ReportItemType type = ReportItemType.Step;
+
 
     /**
      * Getter for {@link #guid} field.
@@ -120,4 +127,5 @@ public final class StepReport extends Report {
     public String toString() {
         return this.description;
     }
+
 }

--- a/src/main/java/io/testproject/sdk/internal/rest/messages/TestReport.java
+++ b/src/main/java/io/testproject/sdk/internal/rest/messages/TestReport.java
@@ -38,6 +38,11 @@ public final class TestReport extends Report {
     private String message;
 
     /**
+     * Define type as Test for batch report support.
+     */
+    private final ReportItemType type = ReportItemType.Test;
+
+    /**
      * Initializes a new instance of a Test Report.
      *
      * @param name Test name.
@@ -121,4 +126,5 @@ public final class TestReport extends Report {
     public String toString() {
         return this.name;
     }
+
 }


### PR DESCRIPTION
Adding logic to support reporting at batches due to issue #145 . 
ReportsQueueBatch was added to support up to 10 reports in a batch. 
Logic added to AgentClient - to support the new ReportsQueue from agent version: 3.0.0