### PR TITLE
fix: make connection timeout with the agent configurable

### DIFF
--- a/src/main/java/io/testproject/sdk/DriverBuilder.java
+++ b/src/main/java/io/testproject/sdk/DriverBuilder.java
@@ -90,6 +90,11 @@ public final class DriverBuilder<T extends ReportingDriver> {
     private String builderReportPath;
 
     /**
+     * The connection timeout to the agent in milliseconds.
+     */
+    private int builderSocketSessionTimeout;
+
+    /**
      * Initializes a new instance of the builder.
      * Builder can be conveniently used to initialize new Drivers.
      *
@@ -204,6 +209,16 @@ public final class DriverBuilder<T extends ReportingDriver> {
     }
 
     /**
+     * Set the connection timeout to the agent in milliseconds.
+     * @param sessionSocketTimeout timeout to the agent in milliseconds.
+     * @return Modified builder.
+     */
+    public DriverBuilder<T> withSessionSocketTimeout(final int sessionSocketTimeout) {
+        this.builderSocketSessionTimeout = sessionSocketTimeout;
+        return this;
+    }
+
+    /**
      * Builds an instance of the requested driver using set values.
      *
      * @param clazz Required driver type.
@@ -222,7 +237,8 @@ public final class DriverBuilder<T extends ReportingDriver> {
                         boolean.class,
                         ReportType.class,
                         String.class,
-                        String.class);
+                        String.class,
+                        Integer.class);
 
         // Make sure that requested constructor was found
         if (constructor == null) {
@@ -241,7 +257,8 @@ public final class DriverBuilder<T extends ReportingDriver> {
                     builderDisableReports,
                     builderReportType,
                     builderReportName,
-                    builderReportPath);
+                    builderReportPath,
+                    builderSocketSessionTimeout);
         } catch (Exception e) {
             throw new WebDriverException("Failed to create an instance of " + clazz.getName(), e);
         }

--- a/src/main/java/io/testproject/sdk/drivers/GenericDriver.java
+++ b/src/main/java/io/testproject/sdk/drivers/GenericDriver.java
@@ -66,6 +66,7 @@ public final class GenericDriver implements ReportingDriver {
      * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
      * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
      * <p>
+     *
      * @throws AgentConnectException    if Agent is not responding or responds with an error
      * @throws InvalidTokenException    if the token provided is invalid
      * @throws IOException              if the Agent API base URL provided is malformed
@@ -134,7 +135,7 @@ public final class GenericDriver implements ReportingDriver {
      * Creates a new instance based on {@code capabilities}.
      *
      * @param disableReports True to disable automatic reporting of driver commands and tests, otherwise False.
-     * @param reportType A type of report to produce - cloud, local or both.
+     * @param reportType     A type of report to produce - cloud, local or both.
      * @throws AgentConnectException    if Agent is not responding or responds with an error
      * @throws InvalidTokenException    if the token provided is invalid
      * @throws IOException              if the Agent API base URL provided is malformed
@@ -180,8 +181,32 @@ public final class GenericDriver implements ReportingDriver {
      * <p>
      * Creates a new instance based on {@code capabilities}.
      *
+     * @param projectName          Project name to report
+     * @param sessionSocketTimeout The connection timeout to the agent in milliseconds
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public GenericDriver(final String projectName, final int sessionSocketTimeout)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(null, null, projectName, null, false, ReportType.CLOUD_AND_LOCAL, sessionSocketTimeout);
+    }
+
+    /**
+     * Initiates a new session with the Agent using default token and URL with Project name.
+     * <p>
+     * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
      * @param projectName Project name to report
-     * @param reportType A type of report to produce - cloud, local or both.
+     * @param reportType  A type of report to produce - cloud, local or both.
      * @throws AgentConnectException    if Agent is not responding or responds with an error
      * @throws InvalidTokenException    if the token provided is invalid
      * @throws IOException              if the Agent API base URL provided is malformed
@@ -231,7 +256,7 @@ public final class GenericDriver implements ReportingDriver {
      *
      * @param projectName Project name to report
      * @param jobName     Job name to report
-     * @param reportType A type of report to produce - cloud, local or both.
+     * @param reportType  A type of report to produce - cloud, local or both.
      * @throws AgentConnectException    if Agent is not responding or responds with an error
      * @throws InvalidTokenException    if the token provided is invalid
      * @throws IOException              if the Agent API base URL provided is malformed
@@ -280,7 +305,7 @@ public final class GenericDriver implements ReportingDriver {
      *                    <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
      * @param projectName Project name to report
      * @param jobName     Job name to report
-     * @param reportType A type of report to produce - cloud, local or both.
+     * @param reportType  A type of report to produce - cloud, local or both.
      * @throws AgentConnectException    if Agent is not responding or responds with an error
      * @throws InvalidTokenException    if the token provided is invalid
      * @throws IOException              if the Agent API base URL provided is malformed
@@ -323,7 +348,7 @@ public final class GenericDriver implements ReportingDriver {
      * Creates a new instance based on {@code capabilities}.
      *
      * @param remoteAddress Agent API base URL (e.g. http://localhost:8585/)
-     * @param reportType A type of report to produce - cloud, local or both.
+     * @param reportType    A type of report to produce - cloud, local or both.
      * @throws AgentConnectException    if Agent is not responding or responds with an error
      * @throws InvalidTokenException    if the token provided is invalid
      * @throws IOException              if the Agent API base URL provided is malformed
@@ -370,7 +395,7 @@ public final class GenericDriver implements ReportingDriver {
      * @param remoteAddress Agent API base URL (e.g. http://localhost:8585/)
      * @param projectName   Project name to report
      * @param jobName       Job name to report
-     * @param reportType A type of report to produce - cloud, local or both.
+     * @param reportType    A type of report to produce - cloud, local or both.
      * @throws AgentConnectException    if Agent is not responding or responds with an error
      * @throws InvalidTokenException    if the token provided is invalid
      * @throws IOException              if the Agent API base URL provided is malformed
@@ -406,10 +431,30 @@ public final class GenericDriver implements ReportingDriver {
     /**
      * Initiates a new session with the Agent using provided Agent URL and token.
      *
+     * @param remoteAddress        Agent API base URL (e.g. http://localhost:8585/)
+     * @param token                Development token that should be obtained from
+     *                             <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param sessionSocketTimeout The connection timeout to the agent in milliseconds
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public GenericDriver(final URL remoteAddress,
+                         final String token,
+                         final int sessionSocketTimeout)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(remoteAddress, token, null, null, false, ReportType.CLOUD_AND_LOCAL, sessionSocketTimeout);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided Agent URL and token.
+     *
      * @param remoteAddress Agent API base URL (e.g. http://localhost:8585/)
      * @param token         Development token that should be obtained from
      *                      <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
-     * @param reportType A type of report to produce - cloud, local or both.
+     * @param reportType    A type of report to produce - cloud, local or both.
      * @throws AgentConnectException    if Agent is not responding or responds with an error
      * @throws InvalidTokenException    if the token provided is invalid
      * @throws IOException              if the Agent API base URL provided is malformed
@@ -432,7 +477,7 @@ public final class GenericDriver implements ReportingDriver {
      * @param projectName    Project name to report
      * @param jobName        Job name to report
      * @param disableReports True to disable automatic reporting of driver commands and tests, otherwise False.
-     * @param reportType A type of report to produce - cloud, local or both.
+     * @param reportType     A type of report to produce - cloud, local or both.
      * @throws AgentConnectException    if Agent is not responding or responds with an error
      * @throws InvalidTokenException    if the token provided is invalid
      * @throws IOException              if the Agent API base URL provided is malformed
@@ -448,21 +493,54 @@ public final class GenericDriver implements ReportingDriver {
             ObsoleteVersionException {
         this(remoteAddress, token, projectName, jobName, disableReports, reportType,
                 null,
-                null);
+                null,
+                AgentClient.NEW_SESSION_SOCKET_TIMEOUT_MS);
     }
 
     /**
      * Initiates a new session with the Agent using provided Agent URL, token, Project and Job names.
      *
-     * @param remoteAddress  Agent API base URL (e.g. http://localhost:8585/)
-     * @param token          Development token that should be obtained from
-     *                       <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
-     * @param projectName    Project name to report
-     * @param jobName        Job name to report
-     * @param disableReports True to disable automatic reporting of driver commands and tests, otherwise False.
-     * @param reportType A type of report to produce - cloud, local or both.
-     * @param reportName     The name of the generated report.
-     * @param reportPath     The path to the generated report.
+     * @param remoteAddress        Agent API base URL (e.g. http://localhost:8585/)
+     * @param token                Development token that should be obtained from
+     *                             <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param projectName          Project name to report
+     * @param jobName              Job name to report
+     * @param disableReports       True to disable automatic reporting of driver commands and tests, otherwise False.
+     * @param reportType           A type of report to produce - cloud, local or both.
+     * @param sessionSocketTimeout The connection timeout to the agent in milliseconds
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public GenericDriver(final URL remoteAddress,
+                         final String token,
+                         final String projectName,
+                         final String jobName,
+                         final boolean disableReports,
+                         final ReportType reportType,
+                         final int sessionSocketTimeout)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(remoteAddress, token, projectName, jobName, disableReports, reportType,
+                null,
+                null,
+                sessionSocketTimeout);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided Agent URL, token, Project and Job names.
+     *
+     * @param remoteAddress        Agent API base URL (e.g. http://localhost:8585/)
+     * @param token                Development token that should be obtained from
+     *                             <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param projectName          Project name to report
+     * @param jobName              Job name to report
+     * @param disableReports       True to disable automatic reporting of driver commands and tests, otherwise False.
+     * @param reportType           A type of report to produce - cloud, local or both.
+     * @param reportName           The name of the generated report.
+     * @param reportPath           The path to the generated report.
+     * @param sessionSocketTimeout The connection timeout to the agent in milliseconds
      * @throws AgentConnectException    if Agent is not responding or responds with an error
      * @throws InvalidTokenException    if the token provided is invalid
      * @throws IOException              if the Agent API base URL provided is malformed
@@ -475,7 +553,8 @@ public final class GenericDriver implements ReportingDriver {
                          final boolean disableReports,
                          final ReportType reportType,
                          final String reportName,
-                         final String reportPath)
+                         final String reportPath,
+                         final int sessionSocketTimeout)
             throws InvalidTokenException, AgentConnectException, IOException,
             ObsoleteVersionException {
 
@@ -493,7 +572,8 @@ public final class GenericDriver implements ReportingDriver {
         }
 
         AgentClient agentClient = AgentClient.getClient(remoteAddress, token, capabilities,
-                new ReportSettings(projectName, jobName, reportType, reportName, reportPath), disableReports);
+                new ReportSettings(projectName, jobName, reportType, reportName, reportPath),
+                disableReports, sessionSocketTimeout);
 
         reportingCommandExecutor = new GenericCommandExecutor(agentClient);
         reportingCommandExecutor.setReportsDisabled(disableReports);

--- a/src/main/java/io/testproject/sdk/drivers/android/AndroidDriver.java
+++ b/src/main/java/io/testproject/sdk/drivers/android/AndroidDriver.java
@@ -97,6 +97,31 @@ public class AndroidDriver<T extends WebElement>
      * Creates a new instance based on {@code capabilities}.
      *
      * @param capabilities take a look at {@link Capabilities}
+     * @param sessionSocketTimeout The connection timeout to the agent in milliseconds
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public AndroidDriver(final Capabilities capabilities, final int sessionSocketTimeout)
+            throws InvalidTokenException, AgentConnectException, MalformedURLException,
+            ObsoleteVersionException {
+        this(null, null, capabilities, null, null, false,
+                ReportType.CLOUD_AND_LOCAL, sessionSocketTimeout);
+    }
+
+    /**
+     * Initiates a new session with the Agent using default token and URL.
+     * <p>
+     * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param capabilities take a look at {@link Capabilities}
      * @param reportType A type of report to produce - cloud, local or both.
      * @throws AgentConnectException    if Agent is not responding or responds with an error
      * @throws InvalidTokenException    if the token provided is invalid
@@ -184,6 +209,34 @@ public class AndroidDriver<T extends WebElement>
             throws InvalidTokenException, AgentConnectException, MalformedURLException,
             ObsoleteVersionException {
         this(null, null, capabilities, projectName, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using default token and URL with Project name.
+     * <p>
+     * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param capabilities take a look at {@link Capabilities}
+     * @param projectName  Project name to report
+     * @param sessionSocketTimeout The connection timeout to the agent in milliseconds
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public AndroidDriver(final Capabilities capabilities,
+                         final String projectName,
+                         final int sessionSocketTimeout)
+            throws InvalidTokenException, AgentConnectException, MalformedURLException,
+            ObsoleteVersionException {
+        this(null, null, capabilities, projectName, null, false,
+                ReportType.CLOUD_AND_LOCAL, sessionSocketTimeout);
     }
 
     /**
@@ -290,6 +343,32 @@ public class AndroidDriver<T extends WebElement>
             throws AgentConnectException, InvalidTokenException, MalformedURLException,
             ObsoleteVersionException {
         this(null, token, capabilities, null, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided token and default URL.
+     * <p>
+     * Default Agent URL can be set using <em>TP_AGENT_URL</em> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param token        Development token that should be obtained from
+     *                     <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param capabilities take a look at {@link Capabilities}
+     * @param sessionSocketTimeout The connection timeout to the agent in milliseconds
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public AndroidDriver(final String token,
+                         final Capabilities capabilities,
+                         final int sessionSocketTimeout)
+            throws AgentConnectException, InvalidTokenException, MalformedURLException,
+            ObsoleteVersionException {
+        this(null, token, capabilities, null, null, false,
+                ReportType.CLOUD_AND_LOCAL, sessionSocketTimeout);
     }
 
     /**
@@ -445,6 +524,31 @@ public class AndroidDriver<T extends WebElement>
             throws AgentConnectException, InvalidTokenException, MalformedURLException,
             ObsoleteVersionException {
         this(remoteAddress, null, capabilities, null, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided Agent URL and default token.
+     * <p>
+     * Default token can be set using <em>TP_DEV_TOKEN</em> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param remoteAddress Agent API base URL (e.g. http://localhost:8585/)
+     * @param capabilities  take a look at {@link Capabilities}
+     * @param sessionSocketTimeout The connection timeout to the agent in milliseconds
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public AndroidDriver(final URL remoteAddress,
+                         final Capabilities capabilities,
+                         final int sessionSocketTimeout)
+            throws AgentConnectException, InvalidTokenException, MalformedURLException,
+            ObsoleteVersionException {
+        this(remoteAddress, null, capabilities, null, null, false,
+                ReportType.CLOUD_AND_LOCAL, sessionSocketTimeout);
     }
 
     /**
@@ -694,8 +798,43 @@ public class AndroidDriver<T extends WebElement>
             ObsoleteVersionException {
         this(remoteAddress, token, capabilities, projectName, jobName, disableReports, reportType,
                 null,
-                null);
+                null,
+                AgentClient.NEW_SESSION_SOCKET_TIMEOUT_MS);
     }
+
+    /**
+     * Initiates a new session with the Agent using provided Agent URL, token, Project and Job names.
+     *
+     * @param remoteAddress  Agent API base URL (e.g. http://localhost:8585/)
+     * @param token          Development token that should be obtained from
+     *                       <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param capabilities   take a look at {@link Capabilities}
+     * @param projectName    Project name to report
+     * @param jobName        Job name to report
+     * @param disableReports True to disable automatic reporting of driver commands and tests, otherwise False.
+     * @param reportType     A type of report to produce - cloud, local or both.
+     * @param sessionSocketTimeout The connection timeout to the agent in milliseconds
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public AndroidDriver(final URL remoteAddress,
+                         final String token,
+                         final Capabilities capabilities,
+                         final String projectName,
+                         final String jobName,
+                         final boolean disableReports,
+                         final ReportType reportType,
+                         final int sessionSocketTimeout)
+            throws AgentConnectException, InvalidTokenException, MalformedURLException,
+            ObsoleteVersionException {
+        this(remoteAddress, token, capabilities, projectName, jobName, disableReports, reportType,
+                null,
+                null,
+                sessionSocketTimeout);
+    }
+
 
     /**
      * Initiates a new session with the Agent using provided Agent URL, token, Project and Job names.
@@ -710,6 +849,7 @@ public class AndroidDriver<T extends WebElement>
      * @param reportType     A type of report to produce - cloud, local or both.
      * @param reportName     The name of the generated report.
      * @param reportPath     The path to the generated report.
+     * @param sessionSocketTimeout The connection timeout to the agent in milliseconds
      * @throws AgentConnectException    if Agent is not responding or responds with an error
      * @throws InvalidTokenException    if the token provided is invalid
      * @throws MalformedURLException    if the Agent API base URL provided is malformed
@@ -723,13 +863,14 @@ public class AndroidDriver<T extends WebElement>
                          final boolean disableReports,
                          final ReportType reportType,
                          final String reportName,
-                         final String reportPath)
+                         final String reportPath,
+                         final int sessionSocketTimeout)
             throws AgentConnectException, InvalidTokenException, MalformedURLException,
             ObsoleteVersionException {
         super(DriverHelper.getHttpCommandExecutor(
                 AgentClient.getClient(remoteAddress, token, capabilities,
                         new ReportSettings(projectName, jobName, reportType, reportName, reportPath),
-                        disableReports), true),
+                        disableReports, sessionSocketTimeout), true),
                 AgentClient.getClient(capabilities).getSession().getCapabilities());
 
         this.reporter = new Reporter(this, AgentClient.getClient(this.getCapabilities()));

--- a/src/main/java/io/testproject/sdk/drivers/ios/IOSDriver.java
+++ b/src/main/java/io/testproject/sdk/drivers/ios/IOSDriver.java
@@ -97,6 +97,31 @@ public class IOSDriver<T extends WebElement>
      * Creates a new instance based on {@code capabilities}.
      *
      * @param capabilities take a look at {@link Capabilities}
+     * @param sessionSocketTimeout The connection timeout to the agent in milliseconds
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public IOSDriver(final Capabilities capabilities, final int sessionSocketTimeout)
+            throws InvalidTokenException, AgentConnectException,
+            MalformedURLException, ObsoleteVersionException {
+        this(null, null, capabilities, null, null, false,
+                ReportType.CLOUD_AND_LOCAL, sessionSocketTimeout);
+    }
+
+    /**
+     * Initiates a new session with the Agent using default token and URL.
+     * <p>
+     * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param capabilities take a look at {@link Capabilities}
      * @param reportType   A type of report to produce - cloud, local or both.
      * @throws AgentConnectException    if Agent is not responding or responds with an error
      * @throws InvalidTokenException    if the token provided is invalid
@@ -300,6 +325,32 @@ public class IOSDriver<T extends WebElement>
      * @param token        Development token that should be obtained from
      *                     <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
      * @param capabilities take a look at {@link Capabilities}
+     * @param sessionSocketTimeout The connection timeout to the agent in milliseconds
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public IOSDriver(final String token,
+                     final Capabilities capabilities,
+                     final int sessionSocketTimeout)
+            throws AgentConnectException, InvalidTokenException, MalformedURLException,
+            ObsoleteVersionException {
+        this(null, token, capabilities, null, null, false,
+                ReportType.CLOUD_AND_LOCAL, sessionSocketTimeout);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided token and default URL.
+     * <p>
+     * Default Agent URL can be set using <em>TP_AGENT_URL</em> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param token        Development token that should be obtained from
+     *                     <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param capabilities take a look at {@link Capabilities}
      * @param reportType   A type of report to produce - cloud, local or both.
      * @throws AgentConnectException    if Agent is not responding or responds with an error
      * @throws InvalidTokenException    if the token provided is invalid
@@ -337,6 +388,34 @@ public class IOSDriver<T extends WebElement>
             throws AgentConnectException, InvalidTokenException, MalformedURLException,
             ObsoleteVersionException {
         this(null, token, capabilities, projectName, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided token and default URL and Project name.
+     * <p>
+     * Default Agent URL can be set using <em>TP_AGENT_URL</em> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param token        Development token that should be obtained from
+     *                     <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param capabilities take a look at {@link Capabilities}
+     * @param projectName  Project name to report
+     * @param sessionSocketTimeout The connection timeout to the agent in milliseconds
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public IOSDriver(final String token,
+                     final Capabilities capabilities,
+                     final String projectName,
+                     final int sessionSocketTimeout)
+            throws AgentConnectException, InvalidTokenException, MalformedURLException,
+            ObsoleteVersionException {
+        this(null, token, capabilities, projectName, null, false,
+                ReportType.CLOUD_AND_LOCAL, sessionSocketTimeout);
     }
 
     /**
@@ -691,7 +770,41 @@ public class IOSDriver<T extends WebElement>
             ObsoleteVersionException {
         this(remoteAddress, token, capabilities, projectName, jobName, disableReports, reportType,
                 null,
-                null);
+                null,
+                AgentClient.NEW_SESSION_SOCKET_TIMEOUT_MS);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided Agent URL, token, Project and Job names.
+     *
+     * @param remoteAddress  Agent API base URL (e.g. http://localhost:8585/)
+     * @param token          Development token that should be obtained from
+     *                       <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param capabilities   take a look at {@link Capabilities}
+     * @param projectName    Project name to report
+     * @param jobName        Job name to report
+     * @param disableReports True to disable automatic reporting of driver commands and tests, otherwise False.
+     * @param reportType     A type of report to produce - cloud, local or both.
+     * @param sessionSocketTimeout The connection timeout to the agent in milliseconds
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public IOSDriver(final URL remoteAddress,
+                     final String token,
+                     final Capabilities capabilities,
+                     final String projectName,
+                     final String jobName,
+                     final boolean disableReports,
+                     final ReportType reportType,
+                     final int sessionSocketTimeout)
+            throws AgentConnectException, InvalidTokenException, MalformedURLException,
+            ObsoleteVersionException {
+        this(remoteAddress, token, capabilities, projectName, jobName, disableReports, reportType,
+                null,
+                null,
+                sessionSocketTimeout);
     }
 
     /**
@@ -707,6 +820,7 @@ public class IOSDriver<T extends WebElement>
      * @param reportType     A type of report to produce - cloud, local or both.
      * @param reportName     The name of the generated report.
      * @param reportPath     The path to the generated report.
+     * @param sessionSocketTimeout The connection timeout to the agent in milliseconds
      * @throws AgentConnectException    if Agent is not responding or responds with an error
      * @throws InvalidTokenException    if the token provided is invalid
      * @throws MalformedURLException    if the Agent API base URL provided is malformed
@@ -720,13 +834,14 @@ public class IOSDriver<T extends WebElement>
                      final boolean disableReports,
                      final ReportType reportType,
                      final String reportName,
-                     final String reportPath)
+                     final String reportPath,
+                     final int sessionSocketTimeout)
             throws AgentConnectException, InvalidTokenException, MalformedURLException,
             ObsoleteVersionException {
         super(DriverHelper.getHttpCommandExecutor(
                 AgentClient.getClient(remoteAddress, token, capabilities,
                         new ReportSettings(projectName, jobName, reportType, reportName, reportPath),
-                        disableReports), true),
+                        disableReports, sessionSocketTimeout), true),
                 AgentClient.getClient(capabilities).getSession().getCapabilities());
 
         this.reporter = new Reporter(this, AgentClient.getClient(this.getCapabilities()));

--- a/src/main/java/io/testproject/sdk/drivers/web/ChromeDriver.java
+++ b/src/main/java/io/testproject/sdk/drivers/web/ChromeDriver.java
@@ -71,7 +71,7 @@ public class ChromeDriver extends org.openqa.selenium.chrome.ChromeDriver implem
     public ChromeDriver()
             throws InvalidTokenException, AgentConnectException, IOException,
             ObsoleteVersionException {
-        this(null, null, new ChromeOptions());
+        this(null, null, new ChromeOptions(), AgentClient.NEW_SESSION_SOCKET_TIMEOUT_MS);
     }
 
     /**
@@ -116,7 +116,31 @@ public class ChromeDriver extends org.openqa.selenium.chrome.ChromeDriver implem
     public ChromeDriver(final ChromeOptions options)
             throws InvalidTokenException, AgentConnectException, IOException,
             ObsoleteVersionException {
-        this(null, null, options);
+        this(null, null, options, AgentClient.NEW_SESSION_SOCKET_TIMEOUT_MS);
+    }
+
+    /**
+     * Initiates a new session with the Agent using default token and URL.
+     * <p>
+     * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param options take a look at {@link ChromeOptions}
+     * @param sessionSocketTimeout The connection timeout to the agent in milliseconds
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public ChromeDriver(final ChromeOptions options, final int sessionSocketTimeout)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(null, null, options, sessionSocketTimeout);
     }
 
     /**
@@ -233,6 +257,34 @@ public class ChromeDriver extends org.openqa.selenium.chrome.ChromeDriver implem
      *
      * @param options     take a look at {@link ChromeOptions}
      * @param projectName Project name to report
+     * @param sessionSocketTimeout The connection timeout to the agent in milliseconds
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public ChromeDriver(final ChromeOptions options,
+                        final String projectName,
+                        final int sessionSocketTimeout)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(null, null, options, projectName, null, false,
+                ReportType.CLOUD_AND_LOCAL, sessionSocketTimeout);
+    }
+
+    /**
+     * Initiates a new session with the Agent using default token and URL with Project name.
+     * <p>
+     * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param options     take a look at {@link ChromeOptions}
+     * @param projectName Project name to report
      * @param reportType  A type of report to produce - cloud, local or both.
      * @throws AgentConnectException    if Agent is not responding or responds with an error
      * @throws InvalidTokenException    if the token provided is invalid
@@ -323,7 +375,33 @@ public class ChromeDriver extends org.openqa.selenium.chrome.ChromeDriver implem
                         final ChromeOptions options)
             throws InvalidTokenException, AgentConnectException, IOException,
             ObsoleteVersionException {
-        this(null, token, options);
+        this(null, token, options, AgentClient.NEW_SESSION_SOCKET_TIMEOUT_MS);
+    }
+
+
+    /**
+     * Initiates a new session with the Agent using provided token and default URL.
+     * <p>
+     * Default Agent URL can be set using <em>TP_AGENT_URL</em> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param token   Development token that should be obtained from
+     *                <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param options take a look at {@link ChromeOptions}
+     * @param sessionSocketTimeout The connection timeout to the agent in milliseconds
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public ChromeDriver(final String token,
+                        final ChromeOptions options,
+                        final int sessionSocketTimeout)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(null, token, options, sessionSocketTimeout);
     }
 
     /**
@@ -471,7 +549,31 @@ public class ChromeDriver extends org.openqa.selenium.chrome.ChromeDriver implem
                         final ChromeOptions options)
             throws InvalidTokenException, AgentConnectException, IOException,
             ObsoleteVersionException {
-        this(remoteAddress, null, options);
+        this(remoteAddress, null, options, AgentClient.NEW_SESSION_SOCKET_TIMEOUT_MS);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided Agent URL and default token.
+     * <p>
+     * Default token can be set using <em>TP_DEV_TOKEN</em> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param remoteAddress Agent API base URL (e.g. http://localhost:8585/)
+     * @param options       take a look at {@link ChromeOptions}
+     * @param sessionSocketTimeout The connection timeout to the agent in milliseconds
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public ChromeDriver(final URL remoteAddress,
+                        final ChromeOptions options,
+                        final int sessionSocketTimeout)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(remoteAddress, null, options, sessionSocketTimeout);
     }
 
     /**
@@ -609,6 +711,29 @@ public class ChromeDriver extends org.openqa.selenium.chrome.ChromeDriver implem
      * @param token         Development token that should be obtained from
      *                      <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
      * @param options       take a look at {@link ChromeOptions}
+     * @param sessionSocketTimeout The connection timeout to the agent in milliseconds
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public ChromeDriver(final URL remoteAddress,
+                        final String token,
+                        final ChromeOptions options,
+                        final int sessionSocketTimeout)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(remoteAddress, token, options, null, null, false,
+                ReportType.CLOUD_AND_LOCAL, sessionSocketTimeout);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided Agent URL and token.
+     *
+     * @param remoteAddress Agent API base URL (e.g. http://localhost:8585/)
+     * @param token         Development token that should be obtained from
+     *                      <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param options       take a look at {@link ChromeOptions}
      * @throws AgentConnectException    if Agent is not responding or responds with an error
      * @throws InvalidTokenException    if the token provided is invalid
      * @throws IOException              if the Agent API base URL provided is malformed
@@ -619,7 +744,8 @@ public class ChromeDriver extends org.openqa.selenium.chrome.ChromeDriver implem
                         final ChromeOptions options)
             throws InvalidTokenException, AgentConnectException, IOException,
             ObsoleteVersionException {
-        this(remoteAddress, token, options, null, null, false, ReportType.CLOUD_AND_LOCAL);
+        this(remoteAddress, token, options, null, null, false,
+                ReportType.CLOUD_AND_LOCAL);
     }
 
     /**
@@ -721,7 +847,39 @@ public class ChromeDriver extends org.openqa.selenium.chrome.ChromeDriver implem
             ObsoleteVersionException {
         this(remoteAddress, token, options, projectName, jobName, disableReports, reportType,
                 null,
-                null);
+                null, AgentClient.NEW_SESSION_SOCKET_TIMEOUT_MS);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided Agent URL, token, Project and Job names.
+     *
+     * @param remoteAddress  Agent API base URL (e.g. http://localhost:8585/)
+     * @param token          Development token that should be obtained from
+     *                       <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param options        take a look at {@link ChromeOptions}
+     * @param projectName    Project name to report
+     * @param jobName        Job name to report
+     * @param disableReports True to disable automatic reporting of driver commands and tests, otherwise False.
+     * @param reportType     A type of report to produce - cloud, local or both.
+     * @param sessionSocketTimeout The connection timeout to the agent in milliseconds
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public ChromeDriver(final URL remoteAddress,
+                        final String token,
+                        final ChromeOptions options,
+                        final String projectName,
+                        final String jobName,
+                        final boolean disableReports,
+                        final ReportType reportType,
+                        final int sessionSocketTimeout)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(remoteAddress, token, options, projectName, jobName, disableReports, reportType,
+                null,
+                null, sessionSocketTimeout);
     }
 
     /**
@@ -737,6 +895,7 @@ public class ChromeDriver extends org.openqa.selenium.chrome.ChromeDriver implem
      * @param reportType     A type of report to produce - cloud, local or both.
      * @param reportName     The name of the generated report.
      * @param reportPath     The path to the generated report.
+     * @param sessionSocketTimeout The connection timeout to the agent in milliseconds
      * @throws AgentConnectException    if Agent is not responding or responds with an error
      * @throws InvalidTokenException    if the token provided is invalid
      * @throws IOException              if the Agent API base URL provided is malformed
@@ -750,12 +909,14 @@ public class ChromeDriver extends org.openqa.selenium.chrome.ChromeDriver implem
                         final boolean disableReports,
                         final ReportType reportType,
                         final String reportName,
-                        final String reportPath)
+                        final String reportPath,
+                        final int sessionSocketTimeout)
             throws InvalidTokenException, AgentConnectException, IOException,
             ObsoleteVersionException {
         super(new FakeDriverService(), new ChromeOptions().merge(AgentClient
                 .getClient(remoteAddress, token, options,
-                        new ReportSettings(projectName, jobName, reportType, reportName, reportPath), disableReports)
+                        new ReportSettings(projectName, jobName, reportType, reportName, reportPath),
+                        disableReports, sessionSocketTimeout)
                 .getSession().getCapabilities()));
 
         this.reporter = new Reporter(this, AgentClient.getClient(this.getCapabilities()));

--- a/src/main/java/io/testproject/sdk/drivers/web/EdgeDriver.java
+++ b/src/main/java/io/testproject/sdk/drivers/web/EdgeDriver.java
@@ -233,6 +233,34 @@ public class EdgeDriver extends org.openqa.selenium.edge.EdgeDriver implements R
      *
      * @param options     take a look at {@link EdgeOptions}
      * @param projectName Project name to report
+     * @param sessionSocketTimeout The connection timeout to the agent in milliseconds
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public EdgeDriver(final EdgeOptions options,
+                      final String projectName,
+                      final int sessionSocketTimeout)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(null, null, options, projectName, null, false,
+                ReportType.CLOUD_AND_LOCAL, sessionSocketTimeout);
+    }
+
+    /**
+     * Initiates a new session with the Agent using default token and URL with Project name.
+     * <p>
+     * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param options     take a look at {@link EdgeOptions}
+     * @param projectName Project name to report
      * @param reportType  A type of report to produce - cloud, local or both.
      * @throws AgentConnectException    if Agent is not responding or responds with an error
      * @throws InvalidTokenException    if the token provided is invalid
@@ -324,6 +352,32 @@ public class EdgeDriver extends org.openqa.selenium.edge.EdgeDriver implements R
             throws InvalidTokenException, AgentConnectException, IOException,
             ObsoleteVersionException {
         this(null, token, options, null, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided token and default URL.
+     * <p>
+     * Default Agent URL can be set using <em>TP_AGENT_URL</em> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param token   Development token that should be obtained from
+     *                <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param options take a look at {@link EdgeOptions}
+     * @param sessionSocketTimeout The connection timeout to the agent in milliseconds
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public EdgeDriver(final String token,
+                      final EdgeOptions options,
+                      final int sessionSocketTimeout)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(null, token, options, null, null, false,
+                ReportType.CLOUD_AND_LOCAL, sessionSocketTimeout);
     }
 
     /**
@@ -728,7 +782,41 @@ public class EdgeDriver extends org.openqa.selenium.edge.EdgeDriver implements R
             ObsoleteVersionException {
         this(remoteAddress, token, options, projectName, jobName, disableReports, reportType,
                 null,
-                null);
+                null,
+                AgentClient.NEW_SESSION_SOCKET_TIMEOUT_MS);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided Agent URL, token, Project and Job names.
+     *
+     * @param remoteAddress  Agent API base URL (e.g. http://localhost:8585/)
+     * @param token          Development token that should be obtained from
+     *                       <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param options        take a look at {@link EdgeOptions}
+     * @param projectName    Project name to report
+     * @param jobName        Job name to report
+     * @param disableReports True to disable automatic reporting of driver commands and tests, otherwise False.
+     * @param reportType     A type of report to produce - cloud, local or both.
+     * @param sessionSocketTimeout The connection timeout to the agent in milliseconds
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public EdgeDriver(final URL remoteAddress,
+                      final String token,
+                      final EdgeOptions options,
+                      final String projectName,
+                      final String jobName,
+                      final boolean disableReports,
+                      final ReportType reportType,
+                      final int sessionSocketTimeout)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(remoteAddress, token, options, projectName, jobName, disableReports, reportType,
+                null,
+                null,
+                sessionSocketTimeout);
     }
 
     /**
@@ -744,6 +832,7 @@ public class EdgeDriver extends org.openqa.selenium.edge.EdgeDriver implements R
      * @param reportType     A type of report to produce - cloud, local or both.
      * @param reportName     The name of the generated report.
      * @param reportPath     The path to the generated report.
+     * @param sessionSocketTimeout The connection timeout to the agent in milliseconds
      * @throws AgentConnectException    if Agent is not responding or responds with an error
      * @throws InvalidTokenException    if the token provided is invalid
      * @throws IOException              if the Agent API base URL provided is malformed
@@ -757,12 +846,14 @@ public class EdgeDriver extends org.openqa.selenium.edge.EdgeDriver implements R
                         final boolean disableReports,
                         final ReportType reportType,
                         final String reportName,
-                        final String reportPath)
+                        final String reportPath,
+                        final int sessionSocketTimeout)
             throws InvalidTokenException, AgentConnectException, IOException,
             ObsoleteVersionException {
         super(new FakeDriverService(), new EdgeOptions().merge(AgentClient
                 .getClient(remoteAddress, token, options,
-                        new ReportSettings(projectName, jobName, reportType, reportName, reportPath), disableReports)
+                        new ReportSettings(projectName, jobName, reportType, reportName, reportPath),
+                        disableReports, sessionSocketTimeout)
                 .getSession().getCapabilities()));
 
         this.reporter = new Reporter(this, AgentClient.getClient(this.getCapabilities()));

--- a/src/main/java/io/testproject/sdk/drivers/web/FirefoxDriver.java
+++ b/src/main/java/io/testproject/sdk/drivers/web/FirefoxDriver.java
@@ -130,6 +130,30 @@ public class FirefoxDriver extends org.openqa.selenium.firefox.FirefoxDriver imp
      * <p>
      * Creates a new instance based on {@code capabilities}.
      *
+     * @param options take a look at {@link FirefoxOptions}
+     * @param sessionSocketTimeout The connection timeout to the agent in milliseconds
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public FirefoxDriver(final FirefoxOptions options, final int sessionSocketTimeout)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(null, null, options, sessionSocketTimeout);
+    }
+
+    /**
+     * Initiates a new session with the Agent using default token and URL.
+     * <p>
+     * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
      * @param options    take a look at {@link FirefoxOptions}
      * @param reportType A type of report to produce - cloud, local or both.
      * @throws AgentConnectException    if Agent is not responding or responds with an error
@@ -218,6 +242,34 @@ public class FirefoxDriver extends org.openqa.selenium.firefox.FirefoxDriver imp
             throws InvalidTokenException, AgentConnectException, IOException,
             ObsoleteVersionException {
         this(null, null, options, projectName, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using default token and URL with Project name.
+     * <p>
+     * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param options     take a look at {@link FirefoxOptions}
+     * @param projectName Project name to report
+     * @param sessionSocketTimeout The connection timeout to the agent in milliseconds
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public FirefoxDriver(final FirefoxOptions options,
+                         final String projectName,
+                         final int sessionSocketTimeout)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(null, null, options, projectName, null, false,
+                ReportType.CLOUD_AND_LOCAL, sessionSocketTimeout);
     }
 
     /**
@@ -324,6 +376,32 @@ public class FirefoxDriver extends org.openqa.selenium.firefox.FirefoxDriver imp
             throws InvalidTokenException, AgentConnectException, IOException,
             ObsoleteVersionException {
         this(null, token, options, null, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided token and default URL.
+     * <p>
+     * Default Agent URL can be set using <em>TP_AGENT_URL</em> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param token   Development token that should be obtained from
+     *                <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param options take a look at {@link FirefoxOptions}
+     * @param sessionSocketTimeout The connection timeout to the agent in milliseconds
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public FirefoxDriver(final String token,
+                         final FirefoxOptions options,
+                         final int sessionSocketTimeout)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(null, token, options, null, null, false,
+                ReportType.CLOUD_AND_LOCAL, sessionSocketTimeout);
     }
 
     /**
@@ -636,6 +714,29 @@ public class FirefoxDriver extends org.openqa.selenium.firefox.FirefoxDriver imp
      * @param token         Development token that should be obtained from
      *                      <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
      * @param options       take a look at {@link FirefoxOptions}
+     * @param sessionSocketTimeout The connection timeout to the agent in milliseconds
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public FirefoxDriver(final URL remoteAddress,
+                         final String token,
+                         final FirefoxOptions options,
+                         final int sessionSocketTimeout)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(remoteAddress, token, options, null, null, false,
+                ReportType.CLOUD_AND_LOCAL, sessionSocketTimeout);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided Agent URL and token.
+     *
+     * @param remoteAddress Agent API base URL (e.g. http://localhost:8585/)
+     * @param token         Development token that should be obtained from
+     *                      <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param options       take a look at {@link FirefoxOptions}
      * @param reportType    A type of report to produce - cloud, local or both.
      * @throws AgentConnectException    if Agent is not responding or responds with an error
      * @throws InvalidTokenException    if the token provided is invalid
@@ -728,7 +829,41 @@ public class FirefoxDriver extends org.openqa.selenium.firefox.FirefoxDriver imp
             ObsoleteVersionException {
         this(remoteAddress, token, options, projectName,  jobName, disableReports, reportType,
                 null,
-                null);
+                null,
+                AgentClient.NEW_SESSION_SOCKET_TIMEOUT_MS);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided Agent URL, token, Project and Job names.
+     *
+     * @param remoteAddress  Agent API base URL (e.g. http://localhost:8585/)
+     * @param token          Development token that should be obtained from
+     *                       <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param options        take a look at {@link FirefoxOptions}
+     * @param projectName    Project name to report
+     * @param jobName        Job name to report
+     * @param disableReports True to disable automatic reporting of driver commands and tests, otherwise False.
+     * @param reportType     A type of report to produce - cloud, local or both.
+     * @param sessionSocketTimeout The connection timeout to the agent in milliseconds
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws IOException              if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public FirefoxDriver(final URL remoteAddress,
+                         final String token,
+                         final FirefoxOptions options,
+                         final String projectName,
+                         final String jobName,
+                         final boolean disableReports,
+                         final ReportType reportType,
+                         final int sessionSocketTimeout)
+            throws InvalidTokenException, AgentConnectException, IOException,
+            ObsoleteVersionException {
+        this(remoteAddress, token, options, projectName,  jobName, disableReports, reportType,
+                null,
+                null,
+                sessionSocketTimeout);
     }
 
     /**
@@ -744,6 +879,7 @@ public class FirefoxDriver extends org.openqa.selenium.firefox.FirefoxDriver imp
      * @param reportType     A type of report to produce - cloud, local or both.
      * @param reportName     The name of the generated report.
      * @param reportPath     The path to the generated report.
+     * @param sessionSocketTimeout The connection timeout to the agent in milliseconds
      * @throws AgentConnectException    if Agent is not responding or responds with an error
      * @throws InvalidTokenException    if the token provided is invalid
      * @throws IOException              if the Agent API base URL provided is malformed
@@ -757,12 +893,14 @@ public class FirefoxDriver extends org.openqa.selenium.firefox.FirefoxDriver imp
                         final boolean disableReports,
                         final ReportType reportType,
                         final String reportName,
-                        final String reportPath)
+                        final String reportPath,
+                        final int sessionSocketTimeout)
             throws InvalidTokenException, AgentConnectException, IOException,
             ObsoleteVersionException {
         super(new FakeDriverService(), new FirefoxOptions().merge(AgentClient
                 .getClient(remoteAddress, token, options,
-                        new ReportSettings(projectName, jobName, reportType, reportName, reportPath), disableReports)
+                        new ReportSettings(projectName, jobName, reportType, reportName, reportPath),
+                        disableReports, sessionSocketTimeout)
                 .getSession().getCapabilities()));
 
         this.reporter = new Reporter(this, AgentClient.getClient(this.getCapabilities()));

--- a/src/main/java/io/testproject/sdk/drivers/web/InternetExplorerDriver.java
+++ b/src/main/java/io/testproject/sdk/drivers/web/InternetExplorerDriver.java
@@ -143,6 +143,30 @@ public class InternetExplorerDriver extends org.openqa.selenium.ie.InternetExplo
      * <p>
      * Creates a new instance based on {@code capabilities}.
      *
+     * @param options take a look at {@link InternetExplorerOptions}
+     * @param sessionSocketTimeout The connection timeout to the agent in milliseconds
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public InternetExplorerDriver(final InternetExplorerOptions options, final int sessionSocketTimeout)
+            throws InvalidTokenException, AgentConnectException, MalformedURLException,
+            ObsoleteVersionException {
+        this(null, null, options, sessionSocketTimeout);
+    }
+
+    /**
+     * Initiates a new session with the Agent using default token and URL.
+     * <p>
+     * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
      * @param options    take a look at {@link InternetExplorerOptions}
      * @param reportType A type of report to produce - cloud, local or both.
      * @throws AgentConnectException    if Agent is not responding or responds with an error
@@ -347,6 +371,32 @@ public class InternetExplorerDriver extends org.openqa.selenium.ie.InternetExplo
      * <p>
      * Creates a new instance based on {@code capabilities}.
      *
+     * @param token   Development token that should be obtained from
+     *                <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param options take a look at {@link InternetExplorerOptions}
+     * @param sessionSocketTimeout The connection timeout to the agent in milliseconds
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public InternetExplorerDriver(final String token,
+                                  final InternetExplorerOptions options,
+                                  final int sessionSocketTimeout)
+            throws InvalidTokenException, AgentConnectException, MalformedURLException,
+            ObsoleteVersionException {
+        this(null, token, options, null, null, false,
+                ReportType.CLOUD_AND_LOCAL, sessionSocketTimeout);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided token and default URL.
+     * <p>
+     * Default Agent URL can be set using <em>TP_AGENT_URL</em> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
      * @param token      Development token that should be obtained from
      *                   <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
      * @param options    take a look at {@link InternetExplorerOptions}
@@ -491,6 +541,30 @@ public class InternetExplorerDriver extends org.openqa.selenium.ie.InternetExplo
             throws InvalidTokenException, AgentConnectException, MalformedURLException,
             ObsoleteVersionException {
         this(remoteAddress, null, options, null, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided Agent URL and default token.
+     * <p>
+     * Default token can be set using <em>TP_DEV_TOKEN</em> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param remoteAddress Agent API base URL (e.g. http://localhost:8585/)
+     * @param options       take a look at {@link InternetExplorerOptions}
+     * @param sessionSocketTimeout The connection timeout to the agent in milliseconds
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public InternetExplorerDriver(final URL remoteAddress, final InternetExplorerOptions options,
+                                  final int sessionSocketTimeout)
+            throws InvalidTokenException, AgentConnectException, MalformedURLException,
+            ObsoleteVersionException {
+        this(remoteAddress, null, options, null, null, false,
+                ReportType.CLOUD_AND_LOCAL, sessionSocketTimeout);
     }
 
     /**
@@ -648,6 +722,29 @@ public class InternetExplorerDriver extends org.openqa.selenium.ie.InternetExplo
      * @param token         Development token that should be obtained from
      *                      <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
      * @param options       take a look at {@link InternetExplorerOptions}
+     * @param sessionSocketTimeout The connection timeout to the agent in milliseconds
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public InternetExplorerDriver(final URL remoteAddress,
+                                  final String token,
+                                  final InternetExplorerOptions options,
+                                  final int sessionSocketTimeout)
+            throws InvalidTokenException, AgentConnectException, MalformedURLException,
+            ObsoleteVersionException {
+        this(remoteAddress, token, options, null, null, false,
+                ReportType.CLOUD_AND_LOCAL, sessionSocketTimeout);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided Agent URL and token.
+     *
+     * @param remoteAddress Agent API base URL (e.g. http://localhost:8585/)
+     * @param token         Development token that should be obtained from
+     *                      <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param options       take a look at {@link InternetExplorerOptions}
      * @param reportType    A type of report to produce - cloud, local or both.
      * @throws AgentConnectException    if Agent is not responding or responds with an error
      * @throws InvalidTokenException    if the token provided is invalid
@@ -690,7 +787,41 @@ public class InternetExplorerDriver extends org.openqa.selenium.ie.InternetExplo
             ObsoleteVersionException {
         this(remoteAddress, token, options, projectName, jobName, disableReports, reportType,
                 null,
-                null);
+                null,
+                AgentClient.NEW_SESSION_SOCKET_TIMEOUT_MS);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided Agent URL, token, Project and Job names.
+     *
+     * @param remoteAddress  Agent API base URL (e.g. http://localhost:8585/)
+     * @param token          Development token that should be obtained from
+     *                       <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param options        take a look at {@link InternetExplorerOptions}
+     * @param projectName    Project name to report
+     * @param jobName        Job name to report
+     * @param disableReports True to disable automatic reporting of driver commands and tests, otherwise False.
+     * @param reportType     A type of report to produce - cloud, local or both.
+     * @param sessionSocketTimeout The connection timeout to the agent in milliseconds
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public InternetExplorerDriver(final URL remoteAddress,
+                                  final String token,
+                                  final InternetExplorerOptions options,
+                                  final String projectName,
+                                  final String jobName,
+                                  final boolean disableReports,
+                                  final ReportType reportType,
+                                  final int sessionSocketTimeout)
+            throws InvalidTokenException, AgentConnectException, MalformedURLException,
+            ObsoleteVersionException {
+        this(remoteAddress, token, options, projectName, jobName, disableReports, reportType,
+                null,
+                null,
+                sessionSocketTimeout);
     }
 
     /**
@@ -756,6 +887,7 @@ public class InternetExplorerDriver extends org.openqa.selenium.ie.InternetExplo
      * @param reportType     A type of report to produce - cloud, local or both.
      * @param reportName     The name of the generated report.
      * @param reportPath     The path to the generated report.
+     * @param sessionSocketTimeout The connection timeout to the agent in milliseconds
      * @throws AgentConnectException    if Agent is not responding or responds with an error
      * @throws InvalidTokenException    if the token provided is invalid
      * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
@@ -769,12 +901,14 @@ public class InternetExplorerDriver extends org.openqa.selenium.ie.InternetExplo
                         final boolean disableReports,
                         final ReportType reportType,
                         final String reportName,
-                        final String reportPath)
+                        final String reportPath,
+                        final int sessionSocketTimeout)
             throws InvalidTokenException, AgentConnectException,
             ObsoleteVersionException, MalformedURLException {
         super(fakeDriverService(), new InternetExplorerOptions().merge(AgentClient
                 .getClient(remoteAddress, token, options,
-                        new ReportSettings(projectName, jobName, reportType, reportName, reportPath), disableReports)
+                        new ReportSettings(projectName, jobName, reportType, reportName, reportPath),
+                        disableReports, sessionSocketTimeout)
                 .getSession().getCapabilities()));
 
         this.reporter = new Reporter(this, AgentClient.getClient(this.getCapabilities()));

--- a/src/main/java/io/testproject/sdk/drivers/web/RemoteWebDriver.java
+++ b/src/main/java/io/testproject/sdk/drivers/web/RemoteWebDriver.java
@@ -86,6 +86,30 @@ public class RemoteWebDriver extends org.openqa.selenium.remote.RemoteWebDriver 
      * Creates a new instance based on {@code capabilities}.
      *
      * @param capabilities take a look at {@link Capabilities}
+     * @param sessionSocketTimeout The connection timeout to the agent in milliseconds
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public RemoteWebDriver(final Capabilities capabilities, final int sessionSocketTimeout)
+            throws AgentConnectException, InvalidTokenException, MalformedURLException,
+            ObsoleteVersionException {
+        this(null, null, capabilities, ReportType.CLOUD_AND_LOCAL, sessionSocketTimeout);
+    }
+
+    /**
+     * Initiates a new session with the Agent using default token and URL.
+     * <p>
+     * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param capabilities take a look at {@link Capabilities}
      * @param reportType   A type of report to produce - cloud, local or both.
      * @throws AgentConnectException    if Agent is not responding or responds with an error
      * @throws InvalidTokenException    if the token provided is invalid
@@ -173,6 +197,34 @@ public class RemoteWebDriver extends org.openqa.selenium.remote.RemoteWebDriver 
             throws AgentConnectException, InvalidTokenException, MalformedURLException,
             ObsoleteVersionException {
         this(null, null, capabilities, projectName, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using default token and URL with Project name.
+     * <p>
+     * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param capabilities take a look at {@link Capabilities}
+     * @param projectName  Project name to report
+     * @param sessionSocketTimeout The connection timeout to the agent in milliseconds
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public RemoteWebDriver(final Capabilities capabilities,
+                           final String projectName,
+                           final int sessionSocketTimeout)
+            throws AgentConnectException, InvalidTokenException, MalformedURLException,
+            ObsoleteVersionException {
+        this(null, null, capabilities, projectName, null, false,
+                ReportType.CLOUD_AND_LOCAL, sessionSocketTimeout);
     }
 
     /**
@@ -279,6 +331,32 @@ public class RemoteWebDriver extends org.openqa.selenium.remote.RemoteWebDriver 
             throws AgentConnectException, InvalidTokenException, MalformedURLException,
             ObsoleteVersionException {
         this(null, token, capabilities, null, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided token and default URL.
+     * <p>
+     * Default Agent URL can be set using <em>TP_AGENT_URL</em> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param token        Development token that should be obtained from
+     *                     <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param capabilities take a look at {@link Capabilities}
+     * @param sessionSocketTimeout The connection timeout to the agent in milliseconds
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public RemoteWebDriver(final String token,
+                           final Capabilities capabilities,
+                           final int sessionSocketTimeout)
+            throws AgentConnectException, InvalidTokenException, MalformedURLException,
+            ObsoleteVersionException {
+        this(null, token, capabilities, null, null, false,
+                ReportType.CLOUD_AND_LOCAL, sessionSocketTimeout);
     }
 
     /**
@@ -495,6 +573,33 @@ public class RemoteWebDriver extends org.openqa.selenium.remote.RemoteWebDriver 
      * @param remoteAddress Agent API base URL (e.g. http://localhost:8585/)
      * @param capabilities  take a look at {@link Capabilities}
      * @param projectName   Project name to report
+     * @param sessionSocketTimeout The connection timeout to the agent in milliseconds
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public RemoteWebDriver(final URL remoteAddress,
+                           final Capabilities capabilities,
+                           final String projectName,
+                           final int sessionSocketTimeout)
+            throws AgentConnectException, InvalidTokenException, MalformedURLException,
+            ObsoleteVersionException {
+        this(remoteAddress, null, capabilities, projectName, null, false,
+                ReportType.CLOUD_AND_LOCAL, sessionSocketTimeout);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided Agent URL, default token and Project name.
+     * <p>
+     * Default token can be set using <em>TP_DEV_TOKEN</em> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param remoteAddress Agent API base URL (e.g. http://localhost:8585/)
+     * @param capabilities  take a look at {@link Capabilities}
+     * @param projectName   Project name to report
      * @param reportType    A type of report to produce - cloud, local or both.
      * @throws AgentConnectException    if Agent is not responding or responds with an error
      * @throws InvalidTokenException    if the token provided is invalid
@@ -607,6 +712,31 @@ public class RemoteWebDriver extends org.openqa.selenium.remote.RemoteWebDriver 
     }
 
     /**
+     * Initiates a new session with the Agent using provided Agent URL and token.
+     *
+     * @param remoteAddress Agent API base URL (e.g. http://localhost:8585/)
+     * @param token         Development token that should be obtained from
+     *                      <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param capabilities  take a look at {@link Capabilities}
+     * @param reportType    A type of report to produce - cloud, local or both.
+     * @param sessionSocketTimeout The connection timeout to the agent in milliseconds
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public RemoteWebDriver(final URL remoteAddress,
+                           final String token,
+                           final Capabilities capabilities,
+                           final ReportType reportType,
+                           final int sessionSocketTimeout)
+            throws AgentConnectException, InvalidTokenException, MalformedURLException,
+            ObsoleteVersionException {
+        this(remoteAddress, token, capabilities, null, null, false,
+                reportType, sessionSocketTimeout);
+    }
+
+    /**
      * Initiates a new session with the Agent using provided Agent URL, token, Project and Job names.
      *
      * @param remoteAddress  Agent API base URL (e.g. http://localhost:8585/)
@@ -633,7 +763,41 @@ public class RemoteWebDriver extends org.openqa.selenium.remote.RemoteWebDriver 
             ObsoleteVersionException {
         this(remoteAddress, token, capabilities, projectName, jobName, disableReports, reportType,
                 null,
-                null);
+                null,
+                AgentClient.NEW_SESSION_SOCKET_TIMEOUT_MS);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided Agent URL, token, Project and Job names.
+     *
+     * @param remoteAddress  Agent API base URL (e.g. http://localhost:8585/)
+     * @param token          Development token that should be obtained from
+     *                       <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param capabilities   take a look at {@link Capabilities}
+     * @param projectName    Project name to report
+     * @param jobName        Job name to report
+     * @param disableReports True to disable automatic reporting of driver commands and tests, otherwise False.
+     * @param reportType     A type of report to produce - cloud, local or both.
+     * @param sessionSocketTimeout The connection timeout to the agent in milliseconds
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public RemoteWebDriver(final URL remoteAddress,
+                           final String token,
+                           final Capabilities capabilities,
+                           final String projectName,
+                           final String jobName,
+                           final boolean disableReports,
+                           final ReportType reportType,
+                           final int sessionSocketTimeout)
+            throws AgentConnectException, InvalidTokenException, MalformedURLException,
+            ObsoleteVersionException {
+        this(remoteAddress, token, capabilities, projectName, jobName, disableReports, reportType,
+                null,
+                null,
+                sessionSocketTimeout);
     }
 
     /**
@@ -699,6 +863,7 @@ public class RemoteWebDriver extends org.openqa.selenium.remote.RemoteWebDriver 
      * @param reportType     A type of report to produce - cloud, local or both.
      * @param reportName     The name of the generated report.
      * @param reportPath     The path to the generated report.
+     * @param sessionSocketTimeout The connection timeout to the agent in milliseconds
      * @throws AgentConnectException    if Agent is not responding or responds with an error
      * @throws InvalidTokenException    if the token provided is invalid
      * @throws MalformedURLException    if the Agent API base URL provided is malformed
@@ -712,11 +877,13 @@ public class RemoteWebDriver extends org.openqa.selenium.remote.RemoteWebDriver 
                            final boolean disableReports,
                            final ReportType reportType,
                            final String reportName,
-                           final String reportPath)
+                           final String reportPath,
+                           final int sessionSocketTimeout)
             throws AgentConnectException, InvalidTokenException, MalformedURLException,
             ObsoleteVersionException {
         super(AgentClient.getClient(remoteAddress, token, capabilities,
-                new ReportSettings(projectName, jobName, reportType, reportName, reportPath), disableReports)
+                new ReportSettings(projectName, jobName, reportType, reportName, reportPath),
+                disableReports, sessionSocketTimeout)
                 .getSession().getCapabilities());
 
         this.reporter = new Reporter(this, AgentClient.getClient(this.getCapabilities()));

--- a/src/main/java/io/testproject/sdk/drivers/web/SafariDriver.java
+++ b/src/main/java/io/testproject/sdk/drivers/web/SafariDriver.java
@@ -129,6 +129,30 @@ public class SafariDriver extends org.openqa.selenium.safari.SafariDriver implem
      * <p>
      * Creates a new instance based on {@code capabilities}.
      *
+     * @param options take a look at {@link SafariOptions}
+     * @param sessionSocketTimeout The connection timeout to the agent in milliseconds
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public SafariDriver(final SafariOptions options, final int sessionSocketTimeout)
+            throws AgentConnectException, InvalidTokenException, MalformedURLException,
+            ObsoleteVersionException {
+        this(null, null, options);
+    }
+
+    /**
+     * Initiates a new session with the Agent using default token and URL.
+     * <p>
+     * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
      * @param options    take a look at {@link SafariOptions}
      * @param reportType A type of report to produce - cloud, local or both.
      * @throws AgentConnectException    if Agent is not responding or responds with an error
@@ -217,6 +241,34 @@ public class SafariDriver extends org.openqa.selenium.safari.SafariDriver implem
             throws AgentConnectException, InvalidTokenException, MalformedURLException,
             ObsoleteVersionException {
         this(null, null, options, projectName, null, false, ReportType.CLOUD_AND_LOCAL);
+    }
+
+    /**
+     * Initiates a new session with the Agent using default token and URL with Project name.
+     * <p>
+     * Default <em>Agent URL</em> can be set using <b>TP_AGENT_URL</b> environment variable.
+     * If the environment variable is not set, default URL <b>http://localhost:8585</b> is used.
+     * <p>
+     * Default <em>token</em> can be set using <b>TP_DEV_TOKEN</b> environment variable.
+     * You can get a token from <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * <p>
+     * Creates a new instance based on {@code capabilities}.
+     *
+     * @param options     take a look at {@link SafariOptions}
+     * @param projectName Project name to report
+     * @param sessionSocketTimeout The connection timeout to the agent in milliseconds
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public SafariDriver(final SafariOptions options,
+                        final String projectName,
+                        final int sessionSocketTimeout)
+            throws AgentConnectException, InvalidTokenException, MalformedURLException,
+            ObsoleteVersionException {
+        this(null, null, options, projectName, null, false,
+                ReportType.CLOUD_AND_LOCAL, sessionSocketTimeout);
     }
 
     /**
@@ -635,6 +687,29 @@ public class SafariDriver extends org.openqa.selenium.safari.SafariDriver implem
      * @param token         Development token that should be obtained from
      *                      <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
      * @param options       take a look at {@link SafariOptions}
+     * @param sessionSocketTimeout The connection timeout to the agent in milliseconds
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public SafariDriver(final URL remoteAddress,
+                        final String token,
+                        final SafariOptions options,
+                        final int sessionSocketTimeout)
+            throws AgentConnectException, InvalidTokenException, MalformedURLException,
+            ObsoleteVersionException {
+        this(remoteAddress, token, options, null, null, false,
+                ReportType.CLOUD_AND_LOCAL, sessionSocketTimeout);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided Agent URL and token.
+     *
+     * @param remoteAddress Agent API base URL (e.g. http://localhost:8585/)
+     * @param token         Development token that should be obtained from
+     *                      <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param options       take a look at {@link SafariOptions}
      * @param reportType    A type of report to produce - cloud, local or both.
      * @throws AgentConnectException    if Agent is not responding or responds with an error
      * @throws InvalidTokenException    if the token provided is invalid
@@ -677,7 +752,41 @@ public class SafariDriver extends org.openqa.selenium.safari.SafariDriver implem
             ObsoleteVersionException {
         this(remoteAddress, token, options, projectName, jobName, disableReports, reportType,
                 null,
-                null);
+                null,
+                AgentClient.NEW_SESSION_SOCKET_TIMEOUT_MS);
+    }
+
+    /**
+     * Initiates a new session with the Agent using provided Agent URL, token, Project and Job names.
+     *
+     * @param remoteAddress  Agent API base URL (e.g. http://localhost:8585/)
+     * @param token          Development token that should be obtained from
+     *                       <a href="https://app.testproject.io/#/integrations/sdk">SDK</a> page
+     * @param options        take a look at {@link SafariOptions}
+     * @param projectName    Project name to report
+     * @param jobName        Job name to report
+     * @param disableReports True to disable automatic reporting of driver commands and tests, otherwise False.
+     * @param reportType     A type of report to produce - cloud, local or both.
+     * @param sessionSocketTimeout The connection timeout to the agent in milliseconds
+     * @throws AgentConnectException    if Agent is not responding or responds with an error
+     * @throws InvalidTokenException    if the token provided is invalid
+     * @throws MalformedURLException    if the Agent API base URL provided is malformed
+     * @throws ObsoleteVersionException if the SDK version is incompatible with the Agent
+     */
+    public SafariDriver(final URL remoteAddress,
+                        final String token,
+                        final SafariOptions options,
+                        final String projectName,
+                        final String jobName,
+                        final boolean disableReports,
+                        final ReportType reportType,
+                        final int sessionSocketTimeout)
+            throws AgentConnectException, InvalidTokenException, MalformedURLException,
+            ObsoleteVersionException {
+        this(remoteAddress, token, options, projectName, jobName, disableReports, reportType,
+                null,
+                null,
+                sessionSocketTimeout);
     }
 
     /**
@@ -743,6 +852,7 @@ public class SafariDriver extends org.openqa.selenium.safari.SafariDriver implem
      * @param reportType     A type of report to produce - cloud, local or both.
      * @param reportName     The name of the generated report.
      * @param reportPath     The path to the generated report.
+     * @param sessionSocketTimeout The connection timeout to the agent in milliseconds
      * @throws AgentConnectException    if Agent is not responding or responds with an error
      * @throws InvalidTokenException    if the token provided is invalid
      * @throws MalformedURLException    if the Agent API base URL provided is malformed
@@ -756,12 +866,14 @@ public class SafariDriver extends org.openqa.selenium.safari.SafariDriver implem
                         final boolean disableReports,
                         final ReportType reportType,
                         final String reportName,
-                        final String reportPath)
+                        final String reportPath,
+                        final int sessionSocketTimeout)
             throws AgentConnectException, InvalidTokenException, MalformedURLException,
             ObsoleteVersionException {
         super(new SafariOptions(AgentClient
                 .getClient(remoteAddress, token, options,
-                        new ReportSettings(projectName, jobName, reportType, reportName, reportPath), disableReports)
+                        new ReportSettings(projectName, jobName, reportType, reportName, reportPath),
+                        disableReports, sessionSocketTimeout)
                 .getSession().getCapabilities()));
 
         this.reporter = new Reporter(this, AgentClient.getClient(this.getCapabilities()));


### PR DESCRIPTION
Let the user configure the timeout of the connection with the agent (in milliseconds)