### PR TITLE
Support creating addons using the java OpenSDK

### DIFF
--- a/src/main/java/io/testproject/sdk/drivers/ActionRunner.java
+++ b/src/main/java/io/testproject/sdk/drivers/ActionRunner.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 TestProject LTD. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.testproject.sdk.drivers;
+
+import io.testproject.sdk.internal.addons.AddonsHelper;
+import org.openqa.selenium.WebDriver;
+
+/**
+ * Extends the ReportingDriver with support for addons execution.
+ * @param <D> Driver type that actions must support.
+ */
+public interface ActionRunner<D extends WebDriver> extends ReportingDriver {
+    /**
+     * Provides access to the addons functionality.
+     *
+     * @return {@link io.testproject.sdk.internal.addons.AddonsHelper} instance.
+     */
+    default AddonsHelper<D> addons() {
+        return new AddonsHelper<>((D) this, getReportingCommandExecutor().getAgentClient());
+    }
+}

--- a/src/main/java/io/testproject/sdk/drivers/GenericDriver.java
+++ b/src/main/java/io/testproject/sdk/drivers/GenericDriver.java
@@ -17,6 +17,7 @@
 
 package io.testproject.sdk.drivers;
 
+import io.testproject.sdk.internal.addons.GenericAddonsHelper;
 import io.testproject.sdk.internal.exceptions.AgentConnectException;
 import io.testproject.sdk.internal.exceptions.InvalidTokenException;
 import io.testproject.sdk.internal.exceptions.ObsoleteVersionException;
@@ -612,5 +613,14 @@ public final class GenericDriver implements ReportingDriver {
             Command command = new Command(null, DriverCommand.QUIT);
             reportingCommandExecutor.reportCommand(command, null);
         }
+    }
+
+    /**
+     * Provides access to the addons functionality.
+     *
+     * @return {@link io.testproject.sdk.internal.addons.GenericAddonsHelper} instance.
+     */
+    public GenericAddonsHelper addons() {
+        return new GenericAddonsHelper(this, getReportingCommandExecutor().getAgentClient());
     }
 }

--- a/src/main/java/io/testproject/sdk/drivers/ReportingDriver.java
+++ b/src/main/java/io/testproject/sdk/drivers/ReportingDriver.java
@@ -17,7 +17,6 @@
 
 package io.testproject.sdk.drivers;
 
-import io.testproject.sdk.internal.addons.AddonsHelper;
 import io.testproject.sdk.internal.helpers.ReportingCommandsExecutor;
 import io.testproject.sdk.internal.reporting.Reporter;
 import org.openqa.selenium.remote.Command;
@@ -72,13 +71,4 @@ public interface ReportingDriver {
      * Stops the driver and perform necessary cleanup.
      */
     void stop();
-
-    /**
-     * Provides access to the addons functionality.
-     *
-     * @return {@link io.testproject.sdk.internal.addons.AddonsHelper} instance.
-     */
-    default AddonsHelper addons() {
-        return new AddonsHelper(getReportingCommandExecutor().getAgentClient());
-    }
 }

--- a/src/main/java/io/testproject/sdk/drivers/android/AndroidDriver.java
+++ b/src/main/java/io/testproject/sdk/drivers/android/AndroidDriver.java
@@ -18,6 +18,7 @@
 package io.testproject.sdk.drivers.android;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.testproject.sdk.drivers.ActionRunner;
 import io.testproject.sdk.drivers.ReportType;
 import io.testproject.sdk.drivers.ReportingDriver;
 import io.testproject.sdk.internal.exceptions.AgentConnectException;
@@ -55,7 +56,8 @@ import java.net.URL;
 // Prevent compiler complaining about type safety caused by raw types
 @SuppressWarnings({"WeakerAccess", "unchecked"})
 public class AndroidDriver<T extends WebElement>
-        extends io.appium.java_client.android.AndroidDriver<T> implements ReportingDriver {
+        extends io.appium.java_client.android.AndroidDriver<T>
+        implements ReportingDriver, ActionRunner<AndroidDriver> {
 
     /**
      * Steps reporter instance.

--- a/src/main/java/io/testproject/sdk/drivers/ios/IOSDriver.java
+++ b/src/main/java/io/testproject/sdk/drivers/ios/IOSDriver.java
@@ -18,6 +18,7 @@
 package io.testproject.sdk.drivers.ios;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.testproject.sdk.drivers.ActionRunner;
 import io.testproject.sdk.drivers.ReportType;
 import io.testproject.sdk.drivers.ReportingDriver;
 import io.testproject.sdk.internal.exceptions.AgentConnectException;
@@ -32,6 +33,7 @@ import io.testproject.sdk.internal.rest.ReportSettings;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.remote.RemoteWebDriver;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -56,7 +58,8 @@ import java.net.URL;
 // Prevent compiler complaining about type safety caused by raw types
 @SuppressWarnings({"WeakerAccess", "unchecked"})
 public class IOSDriver<T extends WebElement>
-        extends io.appium.java_client.ios.IOSDriver<T> implements ReportingDriver {
+        extends io.appium.java_client.ios.IOSDriver<T>
+        implements ReportingDriver, ActionRunner<RemoteWebDriver> {
 
     /**
      * Steps reporter instance.

--- a/src/main/java/io/testproject/sdk/drivers/web/ChromeDriver.java
+++ b/src/main/java/io/testproject/sdk/drivers/web/ChromeDriver.java
@@ -18,6 +18,7 @@
 package io.testproject.sdk.drivers.web;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.testproject.sdk.drivers.ActionRunner;
 import io.testproject.sdk.drivers.ReportType;
 import io.testproject.sdk.drivers.ReportingDriver;
 import io.testproject.sdk.internal.exceptions.AgentConnectException;
@@ -33,6 +34,7 @@ import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.chrome.ChromeDriverService;
 import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.remote.RemoteWebDriver;
 
 import java.io.File;
 import java.io.IOException;
@@ -46,7 +48,8 @@ import java.net.URL;
         value = "NM_SAME_SIMPLE_NAME_AS_SUPERCLASS",
         justification = "Minimize changes required in any migrated tests")
 @SuppressWarnings("WeakerAccess") // Prevent compiler complaining about unused overloaded constructors
-public class ChromeDriver extends org.openqa.selenium.chrome.ChromeDriver implements ReportingDriver {
+public class ChromeDriver extends org.openqa.selenium.chrome.ChromeDriver
+        implements ReportingDriver, ActionRunner<RemoteWebDriver> {
 
     /**
      * Steps reporter instance.

--- a/src/main/java/io/testproject/sdk/drivers/web/EdgeDriver.java
+++ b/src/main/java/io/testproject/sdk/drivers/web/EdgeDriver.java
@@ -18,6 +18,7 @@
 package io.testproject.sdk.drivers.web;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.testproject.sdk.drivers.ActionRunner;
 import io.testproject.sdk.drivers.ReportType;
 import io.testproject.sdk.drivers.ReportingDriver;
 import io.testproject.sdk.internal.exceptions.AgentConnectException;
@@ -33,6 +34,7 @@ import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.edge.EdgeDriverService;
 import org.openqa.selenium.edge.EdgeOptions;
+import org.openqa.selenium.remote.RemoteWebDriver;
 
 import java.io.File;
 import java.io.IOException;
@@ -46,7 +48,8 @@ import java.net.URL;
         value = "NM_SAME_SIMPLE_NAME_AS_SUPERCLASS",
         justification = "Minimize changes required in any migrated tests")
 @SuppressWarnings("WeakerAccess") // Prevent compiler complaining about unused overloaded constructors
-public class EdgeDriver extends org.openqa.selenium.edge.EdgeDriver implements ReportingDriver {
+public class EdgeDriver extends org.openqa.selenium.edge.EdgeDriver
+        implements ReportingDriver, ActionRunner<RemoteWebDriver> {
 
     /**
      * Steps reporter instance.

--- a/src/main/java/io/testproject/sdk/drivers/web/FirefoxDriver.java
+++ b/src/main/java/io/testproject/sdk/drivers/web/FirefoxDriver.java
@@ -18,6 +18,7 @@
 package io.testproject.sdk.drivers.web;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.testproject.sdk.drivers.ActionRunner;
 import io.testproject.sdk.drivers.ReportType;
 import io.testproject.sdk.drivers.ReportingDriver;
 import io.testproject.sdk.internal.exceptions.AgentConnectException;
@@ -33,6 +34,7 @@ import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.firefox.GeckoDriverService;
+import org.openqa.selenium.remote.RemoteWebDriver;
 
 import java.io.File;
 import java.io.IOException;
@@ -46,7 +48,8 @@ import java.net.URL;
         value = "NM_SAME_SIMPLE_NAME_AS_SUPERCLASS",
         justification = "Minimize changes required in any migrated tests")
 @SuppressWarnings("WeakerAccess") // Prevent compiler complaining about unused overloaded constructors
-public class FirefoxDriver extends org.openqa.selenium.firefox.FirefoxDriver implements ReportingDriver {
+public class FirefoxDriver extends org.openqa.selenium.firefox.FirefoxDriver
+        implements ReportingDriver, ActionRunner<RemoteWebDriver> {
 
     /**
      * Steps reporter instance.

--- a/src/main/java/io/testproject/sdk/drivers/web/InternetExplorerDriver.java
+++ b/src/main/java/io/testproject/sdk/drivers/web/InternetExplorerDriver.java
@@ -20,6 +20,7 @@ package io.testproject.sdk.drivers.web;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.testproject.sdk.drivers.ActionRunner;
 import io.testproject.sdk.drivers.ReportType;
 import io.testproject.sdk.drivers.ReportingDriver;
 import io.testproject.sdk.internal.exceptions.AgentConnectException;
@@ -35,6 +36,7 @@ import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.ie.InternetExplorerDriverService;
 import org.openqa.selenium.ie.InternetExplorerOptions;
+import org.openqa.selenium.remote.RemoteWebDriver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,7 +56,7 @@ import java.net.URL;
         justification = "Minimize changes required in any migrated tests")
 @SuppressWarnings("WeakerAccess") // Prevent compiler complaining about unused overloaded constructors
 public class InternetExplorerDriver extends org.openqa.selenium.ie.InternetExplorerDriver
-        implements ReportingDriver {
+        implements ReportingDriver, ActionRunner<RemoteWebDriver> {
 
     /**
      * Steps reporter instance.

--- a/src/main/java/io/testproject/sdk/drivers/web/RemoteWebDriver.java
+++ b/src/main/java/io/testproject/sdk/drivers/web/RemoteWebDriver.java
@@ -18,6 +18,7 @@
 package io.testproject.sdk.drivers.web;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.testproject.sdk.drivers.ActionRunner;
 import io.testproject.sdk.drivers.ReportType;
 import io.testproject.sdk.drivers.ReportingDriver;
 import io.testproject.sdk.internal.exceptions.AgentConnectException;
@@ -44,7 +45,8 @@ import java.net.URL;
         value = "NM_SAME_SIMPLE_NAME_AS_SUPERCLASS",
         justification = "Minimize changes required in any migrated tests")
 @SuppressWarnings("WeakerAccess") // Prevent compiler complaining about unused overloaded constructors
-public class RemoteWebDriver extends org.openqa.selenium.remote.RemoteWebDriver implements ReportingDriver {
+public class RemoteWebDriver extends org.openqa.selenium.remote.RemoteWebDriver
+        implements ReportingDriver, ActionRunner<org.openqa.selenium.remote.RemoteWebDriver> {
 
     /**
      * Steps reporter instance.

--- a/src/main/java/io/testproject/sdk/drivers/web/SafariDriver.java
+++ b/src/main/java/io/testproject/sdk/drivers/web/SafariDriver.java
@@ -18,6 +18,7 @@
 package io.testproject.sdk.drivers.web;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.testproject.sdk.drivers.ActionRunner;
 import io.testproject.sdk.drivers.ReportType;
 import io.testproject.sdk.drivers.ReportingDriver;
 import io.testproject.sdk.internal.exceptions.AgentConnectException;
@@ -31,6 +32,7 @@ import io.testproject.sdk.internal.rest.AgentClient;
 import io.testproject.sdk.internal.rest.ReportSettings;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriverException;
+import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.safari.SafariOptions;
 
 import java.io.IOException;
@@ -45,7 +47,8 @@ import java.net.URL;
         value = "NM_SAME_SIMPLE_NAME_AS_SUPERCLASS",
         justification = "Minimize changes required in any migrated tests")
 @SuppressWarnings("WeakerAccess") // Prevent compiler complaining about unused overloaded constructors
-public class SafariDriver extends org.openqa.selenium.safari.SafariDriver implements ReportingDriver {
+public class SafariDriver extends org.openqa.selenium.safari.SafariDriver
+        implements ReportingDriver, ActionRunner<RemoteWebDriver> {
 
     /**
      * Steps reporter instance.

--- a/src/main/java/io/testproject/sdk/internal/addons/AddonsHelper.java
+++ b/src/main/java/io/testproject/sdk/internal/addons/AddonsHelper.java
@@ -63,7 +63,7 @@ public class AddonsHelper {
      * @return Presumably modified class with updated output fields.
      */
     public ActionProxy execute(final ActionProxy action) {
-        return execute(action, null);
+        return execute(action, -1);
     }
 
     /**
@@ -93,25 +93,6 @@ public class AddonsHelper {
      * @return Presumably modified class with updated output fields.
      */
     public ActionProxy execute(final ActionProxy action, final int timeout) {
-        return execute(action, null, timeout);
-    }
-
-    /**
-     * Executes an Action using it's proxy.
-     * <p>
-     * Addons are tiny automation building blocks that have one or more actions.
-     * Addon Proxy can be obtained from the Addons page at:
-     * <a href="https://app.testproject.io/#/addons">TestProject</a> App.
-     *
-     * @param action  Specific Action proxy.
-     * @param by      Element locator in case the Action needs one.
-     * @param timeout maximum amount of time allowed to wait for action execution to complete.
-     * @return Potentially modified class with updated output fields (if any).
-     */
-    public ActionProxy execute(final ActionProxy action, final By by, final int timeout) {
-        // Set element locator
-        action.getDescriptor().setBy(by);
-
         // Send execution request to the Agent
         ActionExecutionResponse response = agentClient.executeProxy(action, timeout);
         if (response.getResultType() != ActionExecutionResponse.ExecutionResultType.Passed) {
@@ -148,6 +129,24 @@ public class AddonsHelper {
 
         // Return potentially updated proxy.
         return action;
+    }
+
+    /**
+     * Executes an Action using it's proxy.
+     * <p>
+     * Addons are tiny automation building blocks that have one or more actions.
+     * Addon Proxy can be obtained from the Addons page at:
+     * <a href="https://app.testproject.io/#/addons">TestProject</a> App.
+     *
+     * @param action  Specific Action proxy.
+     * @param by      Element locator in case the Action needs one.
+     * @param timeout maximum amount of time allowed to wait for action execution to complete.
+     * @return Potentially modified class with updated output fields (if any).
+     */
+    public ActionProxy execute(final ActionProxy action, final By by, final int timeout) {
+        // Set element locator
+        action.getDescriptor().setBy(by);
+        return execute(action, timeout);
     }
 
     /**

--- a/src/main/java/io/testproject/sdk/internal/addons/AddonsHelper.java
+++ b/src/main/java/io/testproject/sdk/internal/addons/AddonsHelper.java
@@ -17,61 +17,81 @@
 
 package io.testproject.sdk.internal.addons;
 
+import io.testproject.sdk.drivers.ReportingDriver;
+import io.testproject.sdk.internal.addons.interfaces.Action;
+import io.testproject.sdk.internal.addons.interfaces.ElementAction;
 import io.testproject.sdk.internal.rest.AgentClient;
-import io.testproject.sdk.internal.rest.messages.ActionExecutionResponse;
 import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriverException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.openqa.selenium.InvalidArgumentException;
+import org.openqa.selenium.WebDriver;
 
-import java.lang.reflect.Field;
-import java.util.Arrays;
-import java.util.Optional;
+import java.lang.reflect.ParameterizedType;
 
 /**
  * Helper class allowing to execute Addons.
+ * @param <D> The driver type executing the actions.
  */
-public class AddonsHelper extends GenericAddonsHelper {
+public class AddonsHelper<D extends WebDriver> extends GenericAddonsHelper {
     /**
-     * Logger instance.
+     * Driver used in action execution.
      */
-    private static final Logger LOG = LoggerFactory.getLogger(AddonsHelper.class);
-
-    /**
-     * Agent client cached instance.
-     */
-    private final AgentClient agentClient;
+    private final D driver;
 
     /**
      * Initializes a new instance of the helper.
      *
      * @param agentClient Agent client to use for communicating with the Agent.
+     * @param driver Driver.
      */
-    public AddonsHelper(final AgentClient agentClient) {
-        super(null, agentClient);
+    public AddonsHelper(final D driver, final AgentClient agentClient) {
+        super((ReportingDriver) driver, agentClient);
+        this.driver = driver;
+    }
+
+    /**
+     * Runs the action.
+     * @param action Action to run.
+     * @param <T> The driver type that this action supports.
+     * @return True if hte action passed.
+     */
+    public <T extends WebDriver> boolean run(final Action<T> action) {
+        validateAction(action.getClass());
+        return action.run((T) driver);
+    }
+
+    /**
+     * Runs the action.
+     * @param action Action to run.
+     * @param elementSearchCriteria Element search criteria.
+     * @param <T> The driver type that this action supports.
+     * @return True if hte action passed.
+      */
+    public <T extends WebDriver> boolean run(final ElementAction<T> action, final By elementSearchCriteria) {
+        validateAction(action.getClass());
+        return action.run((T) driver, elementSearchCriteria);
+    }
+
+    private void validateAction(final Class<?> actionClass) {
+        ParameterizedType genericInterface = (ParameterizedType) actionClass.getGenericInterfaces()[0];
+        String typeName = genericInterface.getActualTypeArguments()[0].getTypeName()
+                .replaceAll("\\<.*\\>", "");
+        try {
+            if (!Class.forName(typeName).isAssignableFrom(driver.getClass())) {
+                throw new ClassNotFoundException();
+            }
+        } catch (ClassNotFoundException e) {
+            throw new InvalidArgumentException(String.format(
+                    "Driver %s cannot run this action because its driver type must inherit from %s",
+                    driver.getClass().getName(), typeName), e);
+        }
     }
 
     /**
      * Executes an Action using it's proxy.
-     * <p>
      * Addons are tiny automation building blocks that have one or more actions.
-     * Addon Proxy can be obtained from the Addons page at:
-     * <a href="https://app.testproject.io/#/addons">TestProject</a> App.
+     * Addon Proxy can be obtained from the Addons page.
      *
-     * @param action Specific Action proxy.
-     * @return Presumably modified class with updated output fields.
-     */
-    public ActionProxy execute(final ActionProxy action) {
-        return execute(action, -1);
-    }
-
-    /**
-     * Executes an Action using it's proxy.
-     * <p>
-     * Addons are tiny automation building blocks that have one or more actions.
-     * Addon Proxy can be obtained from the Addons page at:
-     * <a href="https://app.testproject.io/#/addons">TestProject</a> App.
-     *
+     * @see <a href="https://app.testproject.io/#/addons">TestProject Addons Page</a>
      * @param action Specific Action proxy.
      * @param by     Element locator in case the Action needs one.
      * @return Presumably modified class with updated output fields.
@@ -84,9 +104,9 @@ public class AddonsHelper extends GenericAddonsHelper {
      * Executes an Action using it's proxy.
      * <p>
      * Addons are tiny automation building blocks that have one or more actions.
-     * Addon Proxy can be obtained from the Addons page at:
-     * <a href="https://app.testproject.io/#/addons">TestProject</a> App.
+     * Addon Proxy can be obtained from the Addons page.
      *
+     * @see <a href="https://app.testproject.io/#/addons">TestProject Addons page</a>.
      * @param action  Specific Action proxy.
      * @param by      Element locator in case the Action needs one.
      * @param timeout maximum amount of time allowed to wait for action execution to complete.

--- a/src/main/java/io/testproject/sdk/internal/addons/GenericAddonsHelper.java
+++ b/src/main/java/io/testproject/sdk/internal/addons/GenericAddonsHelper.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2020 TestProject LTD. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.testproject.sdk.internal.addons;
+
+import io.testproject.sdk.drivers.ReportingDriver;
+import io.testproject.sdk.internal.addons.interfaces.GenericAction;
+import io.testproject.sdk.internal.rest.AgentClient;
+import io.testproject.sdk.internal.rest.messages.ActionExecutionResponse;
+import org.openqa.selenium.WebDriverException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Optional;
+
+/**
+ * Helper class allowing to execute Generic Addons.
+ */
+public class GenericAddonsHelper {
+    /**
+     * Logger instance.
+     */
+    private static final Logger LOG = LoggerFactory.getLogger(AddonsHelper.class);
+
+    /**
+     * Agent client cached instance.
+     */
+    private final AgentClient agentClient;
+    /**
+     * Reporting driver used for action execution.
+     */
+    private final ReportingDriver driver;
+
+    /**
+     * Initializes a new instance of the helper.
+     *
+     * @param agentClient Agent client to use for communicating with the Agent.
+     * @param driver The reporting driver.
+     */
+    public GenericAddonsHelper(final ReportingDriver driver, final AgentClient agentClient) {
+        this.driver = driver;
+        this.agentClient = agentClient;
+    }
+
+    /**
+     * Runs the action.
+     * @param action Action to run.
+     */
+    public void run(final GenericAction action) {
+        action.run(driver.report());
+    }
+
+    /**
+     * Executes an Action using it's proxy.
+     * Addons are tiny automation building blocks that have one or more actions.
+     * Addon Proxy can be obtained from the Addons page.
+     * @see <a href="https://app.testproject.io/#/addons">TestProject Addons page</a>.
+     * @param action Specific Action proxy.
+     * @return Presumably modified class with updated output fields.
+     */
+    public ActionProxy execute(final ActionProxy action) {
+        return execute(action, -1);
+    }
+
+    /**
+     * Executes an Action using it's proxy.
+     *
+     * Addons are tiny automation building blocks that have one or more actions.
+     * Addon Proxy can be obtained from the Addons page.
+     * @see <a href="https://app.testproject.io/#/addons">TestProject Addons page</a>.
+     *
+     * @param action  Specific Action proxy.
+     * @param timeout maximum amount of time allowed to wait for action execution to complete.
+     * @return Presumably modified class with updated output fields.
+     */
+    public ActionProxy execute(final ActionProxy action, final int timeout) {
+        // Send execution request to the Agent
+        ActionExecutionResponse response = agentClient.executeProxy(action, timeout);
+        if (response.getResultType() != ActionExecutionResponse.ExecutionResultType.Passed) {
+            throw new WebDriverException(response.getMessage());
+        }
+
+        // Copy response fields to proxy fields
+        for (ActionExecutionResponse.ResultField field : response.getFields()) {
+
+            // Ignore input fields (even if they are updated - it's wrong!)
+            // Actions should consider input fields readonly,
+            // and set values only into the output fields.
+            if (!field.isOutput()) {
+                continue;
+            }
+
+            // Get the field of the proxy class to update.
+            // This should never fail, but still making sure.
+            Optional<Field> proxyField = Arrays.stream(action.getClass().getDeclaredFields())
+                    .filter(m -> m.getName().equals(field.getName())).findFirst();
+
+            if (proxyField.isEmpty()) {
+                continue;
+            }
+
+            // Use reflection to set the output value
+            proxyField.get().setAccessible(true);
+            try {
+                proxyField.get().set(action, convertToType(proxyField.get().getType(), (String) field.getValue()));
+            } catch (IllegalAccessException e) {
+                LOG.error("Failed to set field [{}] value to [{}]", field.getName(), field.getValue());
+            }
+        }
+
+        // Return potentially updated proxy.
+        return action;
+    }
+
+    /**
+     * Convert string to specified type.
+     * @param clazz target type for conversion..
+     * @param value the value that will be converted.
+     * @return value converted to correct type.
+     */
+    private Object convertToType(final Class<?> clazz, final String value) {
+        if (Boolean.class == clazz || boolean.class == clazz) {
+            return Boolean.parseBoolean(value);
+        }
+        try {
+            if (Byte.class == clazz || byte.class == clazz) {
+                return Byte.parseByte(value);
+            }
+            if (Short.class == clazz || short.class == clazz) {
+                return Short.parseShort(value);
+            }
+            if (Integer.class == clazz || int.class == clazz) {
+                return Integer.parseInt(value);
+            }
+            if (Long.class == clazz || long.class == clazz) {
+                return Long.parseLong(value);
+            }
+            if (Float.class == clazz || float.class == clazz) {
+                return Float.parseFloat(value);
+            }
+            if (Double.class == clazz || double.class == clazz) {
+                return Double.parseDouble(value);
+            }
+            return value;
+        } catch (NumberFormatException e) {
+            LOG.error("Error parsing {} to {}", value, clazz, e);
+            throw new IllegalArgumentException(String.format("Could not parse %s to %s", value, clazz.toString()));
+        }
+    }
+}

--- a/src/main/java/io/testproject/sdk/internal/addons/ParameterDirection.java
+++ b/src/main/java/io/testproject/sdk/internal/addons/ParameterDirection.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2021 TestProject LTD. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.testproject.sdk.internal.addons;
+
+/**
+ * Indicates a parameter's direction.
+ */
+public enum ParameterDirection {
+    /**
+     * Input parameter.
+     */
+    INPUT,
+    /**
+     * Output parameter.
+     */
+    OUTPUT
+}

--- a/src/main/java/io/testproject/sdk/internal/addons/Platform.java
+++ b/src/main/java/io/testproject/sdk/internal/addons/Platform.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2022 TestProject LTD. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.testproject.sdk.internal.addons;
+
+/**
+ * The platforms addons can run on.
+ */
+public enum Platform {
+    /**
+     * Web browsers (e.g. Chrome/Firefox).
+     */
+    Web,
+    /**
+     * Android devices.
+     */
+    Android,
+    /**
+     * IOS devices.
+     */
+    iOS,
+    /**
+     * Generic (no driver).
+     */
+    Any
+}

--- a/src/main/java/io/testproject/sdk/internal/addons/annotations/AddonAction.java
+++ b/src/main/java/io/testproject/sdk/internal/addons/annotations/AddonAction.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2021 TestProject LTD. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.testproject.sdk.internal.addons.annotations;
+
+import io.testproject.sdk.internal.addons.Platform;
+
+import java.lang.annotation.*;
+
+/**
+ * Adds information to a TestProject action regarding what platforms it can run on and how it is displayed.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Inherited
+public @interface AddonAction {
+    /**
+     * List of platforms this action supports.
+     * @return List of platforms.
+     */
+    Platform[] platforms();
+    /**
+     * Alternative action name.
+     * @return Action name.
+     */
+    String name() default "";
+
+    /**
+     * Short summary explaining what the action does.
+     * @return Action summary.
+     */
+    String summary() default "";
+
+    /**
+     * The full description of the action. This is how the action step will be shown in the logs.
+     * You can enhance this by adding step parameters or step element marked with double-brackets (e.g. {{element}}).
+     * @return Action description.
+     */
+    String description() default "";
+}

--- a/src/main/java/io/testproject/sdk/internal/addons/annotations/Parameter.java
+++ b/src/main/java/io/testproject/sdk/internal/addons/annotations/Parameter.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2021 TestProject LTD. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.testproject.sdk.internal.addons.annotations;
+
+import io.testproject.sdk.internal.addons.ParameterDirection;
+
+import java.lang.annotation.*;
+
+/**
+ * Marks a field in an action as a parameter that can be specified at runtime.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+@Inherited
+public @interface Parameter {
+    /**
+     * A short description of the parameter, that will be displayed in the TestProject Test.
+     * @return Parameter description.
+     */
+    String description() default "";
+
+    /**
+     * Indicates whether the parameter is an input or output parameter.
+     * @return If parameter is input/output.
+     */
+    ParameterDirection direction() default ParameterDirection.INPUT;
+
+    /**
+     * Parameter's default value. This is optional and should be reinforced in code as well.
+     * @return Parameter default value.
+     */
+    String defaultValue() default "";
+
+    /**
+     * Indicates this parameter is optional.
+     * @return If parameter is optional.
+     */
+    boolean optional() default false;
+}

--- a/src/main/java/io/testproject/sdk/internal/addons/annotations/package-info.java
+++ b/src/main/java/io/testproject/sdk/internal/addons/annotations/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2021 TestProject LTD. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Annotations used to recognize an action belongs to a specific platform.
+ */
+package io.testproject.sdk.internal.addons.annotations;

--- a/src/main/java/io/testproject/sdk/internal/addons/interfaces/Action.java
+++ b/src/main/java/io/testproject/sdk/internal/addons/interfaces/Action.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 TestProject LTD. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.testproject.sdk.internal.addons.interfaces;
+
+import org.openqa.selenium.WebDriver;
+
+/**
+ * Represents an addon action that can be uploaded and executed inside a recorder test.
+ * @param <D> Driver type supported by this action.
+ */
+public interface Action<D extends WebDriver> {
+    /**
+     * Implementation of the action code.
+     * @param driver The driver used by the action.
+     * @return True if action passed.
+     */
+    boolean run(D driver);
+}

--- a/src/main/java/io/testproject/sdk/internal/addons/interfaces/ElementAction.java
+++ b/src/main/java/io/testproject/sdk/internal/addons/interfaces/ElementAction.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021 TestProject LTD. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.testproject.sdk.internal.addons.interfaces;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+
+/**
+ * Represents an element action that can be uploaded and executed inside a recorder test.
+ * @param <D> Driver type supported by this action.
+ */
+public interface ElementAction<D extends WebDriver> {
+    /**
+     * Implementation of the action code.
+     * @param driver The driver used by the action.
+     * @param elementSearchCriteria Search criteria used to find the element.
+     * @return True if action passed.
+     */
+    boolean run(D driver, By elementSearchCriteria);
+}

--- a/src/main/java/io/testproject/sdk/internal/addons/interfaces/GenericAction.java
+++ b/src/main/java/io/testproject/sdk/internal/addons/interfaces/GenericAction.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 TestProject LTD. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.testproject.sdk.internal.addons.interfaces;
+
+import io.testproject.sdk.internal.reporting.Reporter;
+
+/**
+ * Represents an action that can be uploaded and executed inside a recorder test and doesn't require a driver to run.
+ */
+public interface GenericAction {
+    /**
+     * Implement of the action code.
+     * @param reporter Reporter allowing us to report action result.
+     * @return True if action passed.
+     */
+    boolean run(Reporter reporter);
+}

--- a/src/main/java/io/testproject/sdk/internal/addons/interfaces/package-info.java
+++ b/src/main/java/io/testproject/sdk/internal/addons/interfaces/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2021 TestProject LTD. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Interfaces representing addon actions.
+ */
+package io.testproject.sdk.internal.addons.interfaces;

--- a/src/main/java/io/testproject/sdk/internal/reporting/Reporter.java
+++ b/src/main/java/io/testproject/sdk/internal/reporting/Reporter.java
@@ -55,6 +55,11 @@ public final class Reporter {
     private final ReportingDriver driver;
 
     /**
+     * An action's result. This value will be reported after the addon is uploaded.
+     */
+    private String result;
+
+    /**
      * Initializes a new instance using provided driver and agentClient.
      *
      * @param driver      Driver instance to be used for taking screenshots.
@@ -292,5 +297,13 @@ public final class Reporter {
         }
 
         return new ClosableTestReport(agentClient, driver, name, passed, message);
+    }
+
+    /**
+     * Reports the result of an action execution. This is only sent when addon is executed after upload.
+     * @param message Action result.
+     */
+    public void result(final String message) {
+        this.result = message;
     }
 }

--- a/src/test/java/io/testproject/sdk/tests/examples/addons/AddonsWithParameterTest.java
+++ b/src/test/java/io/testproject/sdk/tests/examples/addons/AddonsWithParameterTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2021 TestProject LTD. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.testproject.sdk.tests.examples.addons;
+
+import io.testproject.sdk.drivers.web.ChromeDriver;
+import io.testproject.sdk.internal.exceptions.AgentConnectException;
+import io.testproject.sdk.internal.exceptions.InvalidTokenException;
+import io.testproject.sdk.internal.exceptions.ObsoleteVersionException;
+import io.testproject.sdk.tests.examples.addons.actions.TypeWithEnterAction;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.openqa.selenium.By;
+import org.openqa.selenium.chrome.ChromeOptions;
+
+import java.io.IOException;
+
+@EnabledIfEnvironmentVariable(named = "TP_DEV_TOKEN", matches = ".*?")
+@DisplayName("Addon With Parameters")
+public class AddonsWithParameterTest {
+    /**
+     * Password to type.
+     */
+    public static final String PASSWORD_TEXT = "12345";
+    /**
+     * Driver instance.
+     */
+    private static ChromeDriver driver;
+
+    @BeforeAll
+    static void setup() throws InvalidTokenException, AgentConnectException, ObsoleteVersionException, IOException {
+        driver = new ChromeDriver(new ChromeOptions(), "Examples");
+    }
+
+    /**
+     * Executes the action on TestProject Example Website.
+     */
+    @Test
+    public void executeTest() {
+        driver.navigate().to("http://example.testproject.io");
+        driver.findElement(By.cssSelector("#name")).sendKeys("John Smith");
+        TypeWithEnterAction action = new TypeWithEnterAction();
+        action.setText(PASSWORD_TEXT);
+        driver.addons().run(action, By.cssSelector("#password"));
+    }
+}

--- a/src/test/java/io/testproject/sdk/tests/examples/addons/AndroidAddonTests.java
+++ b/src/test/java/io/testproject/sdk/tests/examples/addons/AndroidAddonTests.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2021 TestProject LTD. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.testproject.sdk.tests.examples.addons;
+
+import io.appium.java_client.MobileElement;
+import io.appium.java_client.remote.MobileCapabilityType;
+import io.appium.java_client.remote.MobilePlatform;
+import io.testproject.sdk.drivers.ActionRunner;
+import io.testproject.sdk.drivers.android.AndroidDriver;
+import io.testproject.sdk.drivers.web.ChromeDriver;
+import io.testproject.sdk.internal.exceptions.AgentConnectException;
+import io.testproject.sdk.internal.exceptions.InvalidTokenException;
+import io.testproject.sdk.internal.exceptions.ObsoleteVersionException;
+import io.testproject.sdk.tests.examples.addons.actions.ClearFieldsAndroid;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.openqa.selenium.By;
+import org.openqa.selenium.InvalidArgumentException;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.remote.CapabilityType;
+import org.openqa.selenium.remote.DesiredCapabilities;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Example of using a web action defined for multiple browsers.
+ */
+@EnabledIfEnvironmentVariable(named = "TP_DEV_TOKEN", matches = ".*?")
+@DisplayName("Android Addon")
+public class AndroidAddonTests {
+    /**
+     * Default implicit timeout.
+     */
+    public static final int TIMEOUT = 5;
+
+    /**
+     * Runs the action on and android device.
+     * @throws InvalidTokenException
+     * @throws MalformedURLException
+     * @throws ObsoleteVersionException
+     * @throws AgentConnectException
+     */
+    @Test
+    public void androidTest()
+            throws InvalidTokenException, MalformedURLException, ObsoleteVersionException, AgentConnectException {
+        DesiredCapabilities capabilities = new DesiredCapabilities();
+
+        capabilities.setCapability(MobileCapabilityType.PLATFORM_NAME, MobilePlatform.ANDROID);
+        capabilities.setCapability(MobileCapabilityType.UDID, "{YOUR_DEVICE_UDID}");
+        capabilities.setCapability(CapabilityType.BROWSER_NAME, "");
+        capabilities.setCapability(MobileCapabilityType.APP,
+                "https://github.com/testproject-io/android-demo-app/raw/master/APK/testproject-demo-app.apk");
+
+        AndroidDriver<MobileElement> driver = new AndroidDriver<>(capabilities);
+        driver.manage().timeouts().implicitlyWait(TIMEOUT, TimeUnit.SECONDS);
+
+        // Reset App
+        driver.resetApp();
+
+        // Login using provided credentials
+        driver.findElement(By.id("name")).sendKeys("John Smith");
+        driver.findElement(By.id("password")).sendKeys("12345");
+        runAction(driver);
+    }
+
+    /**
+     * Attempts to run the action on chrome driver. We expect this to fail.
+     * @throws InvalidTokenException
+     * @throws ObsoleteVersionException
+     * @throws AgentConnectException
+     * @throws IOException
+     */
+    @Test
+    public void chromeTest()
+            throws InvalidTokenException, ObsoleteVersionException, AgentConnectException, IOException {
+        ChromeDriver driver = new ChromeDriver(new ChromeOptions(), "Examples");
+        Assertions.assertThrows(InvalidArgumentException.class, () -> runAction(driver));
+    }
+
+    private <D extends RemoteWebDriver> void runAction(final ActionRunner<D> runner) {
+        ClearFieldsAndroid action = new ClearFieldsAndroid();
+        runner.addons().run(action);
+    }
+}

--- a/src/test/java/io/testproject/sdk/tests/examples/addons/WebAddonTests.java
+++ b/src/test/java/io/testproject/sdk/tests/examples/addons/WebAddonTests.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2021 TestProject LTD. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.testproject.sdk.tests.examples.addons;
+
+import io.testproject.sdk.drivers.ActionRunner;
+import io.testproject.sdk.drivers.web.ChromeDriver;
+import io.testproject.sdk.drivers.web.FirefoxDriver;
+import io.testproject.sdk.internal.exceptions.AgentConnectException;
+import io.testproject.sdk.internal.exceptions.InvalidTokenException;
+import io.testproject.sdk.internal.exceptions.ObsoleteVersionException;
+import io.testproject.sdk.tests.examples.addons.actions.ClearFieldsWeb;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.firefox.FirefoxOptions;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import java.io.IOException;
+
+/**
+ * Example of using a web action defined for multiple browsers.
+ */
+@EnabledIfEnvironmentVariable(named = "TP_DEV_TOKEN", matches = ".*?")
+@DisplayName("Web Addon")
+public class WebAddonTests {
+    /**
+     * Runs Clear Fields action on chrome.
+     * @throws InvalidTokenException
+     * @throws ObsoleteVersionException
+     * @throws AgentConnectException
+     * @throws IOException
+     */
+    @Test
+    public void chromeTest()
+            throws InvalidTokenException, ObsoleteVersionException, AgentConnectException, IOException {
+        ChromeDriver driver = new ChromeDriver(new ChromeOptions(), "Examples");
+        runAction(driver);
+    }
+
+    /**
+     * Runs Clear Fields action on firefox.
+     * @throws InvalidTokenException
+     * @throws ObsoleteVersionException
+     * @throws AgentConnectException
+     * @throws IOException
+     */
+    @Test
+    public void firefoxTest()
+            throws InvalidTokenException, ObsoleteVersionException, AgentConnectException, IOException {
+        FirefoxDriver driver = new FirefoxDriver(new FirefoxOptions(), "Examples");
+        runAction(driver);
+    }
+
+    private <D extends RemoteWebDriver> void runAction(final ActionRunner<D> runner) {
+        ClearFieldsWeb action = new ClearFieldsWeb();
+        runner.addons().run(action);
+    }
+}

--- a/src/test/java/io/testproject/sdk/tests/examples/addons/actions/ClearFieldsAndroid.java
+++ b/src/test/java/io/testproject/sdk/tests/examples/addons/actions/ClearFieldsAndroid.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2021 TestProject LTD. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.testproject.sdk.tests.examples.addons.actions;
+
+import io.testproject.sdk.drivers.android.AndroidDriver;
+import io.testproject.sdk.internal.addons.interfaces.Action;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+/**
+ * Clears all edit text boxes in android.
+ * This action can run on android only and therefore supports only AndroidDriver.
+ * However, it doesn't require a specific annotation since the driver is specific enough.
+ */
+public final class ClearFieldsAndroid implements Action<AndroidDriver<WebElement>> {
+    @Override
+    public boolean run(final AndroidDriver<WebElement> driver) {
+        for (WebElement element : driver.findElements(By.className("android.widget.EditText"))) {
+            element.clear();
+        }
+
+        return true;
+    }
+}

--- a/src/test/java/io/testproject/sdk/tests/examples/addons/actions/ClearFieldsWeb.java
+++ b/src/test/java/io/testproject/sdk/tests/examples/addons/actions/ClearFieldsWeb.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2021 TestProject LTD. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.testproject.sdk.tests.examples.addons.actions;
+
+import io.testproject.sdk.internal.addons.Platform;
+import io.testproject.sdk.internal.addons.annotations.AddonAction;
+import io.testproject.sdk.internal.addons.interfaces.Action;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.WebDriver;
+
+/**
+ * Clears fields in a web application.
+ * This action can work for all browsers and must therefore use selenium's WebDriver as its driver type.
+ * To prevent it from being available for mobile, we add the AddonAction annotation.
+ */
+@AddonAction(platforms = Platform.Web, name = "Clear Fields")
+public final class ClearFieldsWeb implements Action<WebDriver> {
+    @Override
+    public boolean run(final WebDriver driver) {
+        // Search for Form elements
+        for (WebElement form : driver.findElements(By.tagName("form"))) {
+
+            // Ignore invisible forms
+            if (!form.isDisplayed()) {
+                continue;
+            }
+
+            // Clear all inputs
+            for (WebElement element : form.findElements(By.tagName("input"))) {
+                element.clear();
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/test/java/io/testproject/sdk/tests/examples/addons/actions/TypeWithEnterAction.java
+++ b/src/test/java/io/testproject/sdk/tests/examples/addons/actions/TypeWithEnterAction.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2021 TestProject LTD. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.testproject.sdk.tests.examples.addons.actions;
+
+import io.testproject.sdk.internal.addons.Platform;
+import io.testproject.sdk.internal.addons.annotations.AddonAction;
+import io.testproject.sdk.internal.addons.annotations.Parameter;
+import io.testproject.sdk.internal.addons.interfaces.ElementAction;
+import org.openqa.selenium.*;
+
+import java.util.Optional;
+
+/**
+ * Action that types test and presses the Enter key afterwards.
+ */
+@AddonAction(
+        platforms = {Platform.Android, Platform.iOS, Platform.Web},
+        name = "Type & press Enter",
+        summary = "Types text & presses Enter",
+        description = "Type {{text}} and press Enter")
+public final class TypeWithEnterAction implements ElementAction<WebDriver> {
+    /**
+     * Text to type.
+     */
+    @Parameter(description = "Text to type.")
+    private String text;
+
+    /**
+     * Sets the text parameter. Used for testing the action only.
+     * @param text Text value.
+     */
+    public void setText(final String text) {
+        this.text = text;
+    }
+
+    @Override
+    public boolean run(final WebDriver driver, final By elementSearchCriteria) {
+        text = Optional.of(text).orElse("");
+        WebElement element = driver.findElement(elementSearchCriteria);
+        element.click();
+        element.sendKeys(text);
+        element.sendKeys(Keys.ENTER);
+        return true;
+    }
+}

--- a/src/test/java/io/testproject/sdk/tests/examples/addons/actions/package-info.java
+++ b/src/test/java/io/testproject/sdk/tests/examples/addons/actions/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2021 TestProject LTD. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Specifies actions for example tests.
+ */
+package io.testproject.sdk.tests.examples.addons.actions;


### PR DESCRIPTION
This PR comes to implement all missing code required to develop and test an addon locally. It completes #166 

For it to be ready for review we must also add the following:

-  Clear example how to develop & test an addon action
-  Clear documentation explaining the flow of creating actions with the OpenSDK